### PR TITLE
Fix for NPE, caused by exceptions thrown within ITestListener

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -635,7 +635,6 @@ public class Invoker implements IInvoker {
       testResult.setParameters(parameterValues);
       testResult.setHost(m_testContext.getHost());
       testResult.setStatus(ITestResult.STARTED);
-      runTestListeners(testResult);
 
       invokedMethod= new InvokedMethod(instance,
           tm,
@@ -643,6 +642,8 @@ public class Invoker implements IInvoker {
           true /* isTest */,
           false /* isConfiguration */,
           System.currentTimeMillis());
+
+      runTestListeners(testResult);
 
       runInvokedMethodListeners(true /* before */, invokedMethod, testResult);
 


### PR DESCRIPTION
Hi Cedric, hi all,

found a tiny fix for the problem described here: 
http://groups.google.com/group/testng-users/browse_thread/thread/4f9cc40ecdf501ac#

I did not manage to run the unit tests quickly, because I had no clue how to tell maven where it should pick up the doclet API. Following the instructions in README.build, including copying the ivy jar to $HOME/.ant/lib still resulted in no success (ant refused to load the ivy task from ~/.ant/lib). Maybe you can run the unit tests? I'm just hoping that I do not break any test with this change...

Kind regards

Ansgar
