### PR TITLE
TESTNG-282 : exclude/include tags not working within package config element

### DIFF
--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -444,6 +444,8 @@ public class TestNGContentHandler extends DefaultHandler {
       }
       m_currentTest.setIncludedGroups(m_currentIncludedGroups);
       m_currentTest.setExcludedGroups(m_currentExcludedGroups);
+
+      m_currentRuns = null;
     }
   }
 


### PR DESCRIPTION
This is a long raised bug, with a seemingly simple fix. Problem could be easily produced using e.g. reported in the jira description. Don't think this breaks anything existing.
