### PR TITLE
Should import of RemoteTestListener be restored?

### DIFF
--- a/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -17,6 +17,7 @@ import org.testng.remote.strprotocol.GenericMessage;
 import org.testng.remote.strprotocol.IMessageSender;
 import org.testng.remote.strprotocol.MessageHelper;
 import org.testng.remote.strprotocol.MessageHub;
+import org.testng.remote.strprotocol.RemoteTestListener;
 import org.testng.remote.strprotocol.SerializedMessageSender;
 import org.testng.remote.strprotocol.StringMessageSender;
 import org.testng.remote.strprotocol.SuiteMessage;


### PR DESCRIPTION
...because it still used by RemoteTestNG.DelegatingTestRunnerFactory's
newTestRunner(ISuite, XmlTest, List<IInvokedMethodListener>) method.

Signed-off-by: Mykola Nikishov mn@mn.com.ua
