### PR TITLE
Fix for issue 89

### DIFF
--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -818,6 +818,7 @@ public class TestRunner
       if (test != null && (test.getSequential() || test.getSingleThreaded()) ||
           XmlSuite.PARALLEL_CLASSES.equals(m_xmlTest.getParallel())) {
         sequentialClasses.add(cls);
+        sequentialClasses.add(m.getTestClass().getRealClass());
       }
     }
 
@@ -831,7 +832,6 @@ public class TestRunner
     //
     methodInstances = m_methodInterceptor.intercept(methodInstances, this);
     Map<String, String> params = m_xmlTest.getParameters();
-
     Set<Class<?>> processedClasses = Sets.newHashSet();
     for (IMethodInstance im : methodInstances) {
       Class<?> c = im.getMethod().getTestClass().getRealClass();
@@ -1136,13 +1136,11 @@ public class TestRunner
       ITestNGMethod[] methods, XmlTest test)
   {
     Map<String, List<ITestNGMethod>> classes = Maps.newHashMap();
-    // Note: use a List here to preserve the ordering but make sure
-    // we don't add the same class twice
     List<XmlClass> sortedClasses = Lists.newArrayList();
 
     for (XmlClass c : test.getXmlClasses()) {
       classes.put(c.getName(), new ArrayList<ITestNGMethod>());
-      if (! sortedClasses.contains(c)) sortedClasses.add(c);
+      sortedClasses.add(c);
     }
 
     // Sort the classes based on their order of appearance in the XML

--- a/src/test/java/test/bug89/A.java
+++ b/src/test/java/test/bug89/A.java
@@ -1,0 +1,23 @@
+package test.bug89;
+
+import org.testng.annotations.Test;
+
+public abstract class A {
+	static String threadA="";
+	
+    @Test
+    public void someMethodA1() throws InterruptedException {
+        scenario("someMethodA1");
+        threadA = ""+Thread.currentThread();
+    }
+
+    public void scenario(String s) throws InterruptedException {
+        System.out.println("START["+Thread.currentThread()+"]: " + s);
+        synchronized (s) { 
+            s.wait(1000);
+        }
+        System.out.println("END["+Thread.currentThread()+"]: " + s);
+    }
+    
+
+}	

--- a/src/test/java/test/bug89/B.java
+++ b/src/test/java/test/bug89/B.java
@@ -1,0 +1,20 @@
+package test.bug89;
+
+import org.testng.annotations.Test;
+
+public abstract class B extends A{
+	public static boolean isSameThread=false;
+	static String threadB="";
+    @Test
+    public void someMethodB1 () throws InterruptedException {
+        scenario("someMethodB1");
+        threadB = ""+Thread.currentThread();
+        System.out.println(threadA);
+        System.out.println(threadB);
+        if(threadA.equalsIgnoreCase(threadB)){
+        	isSameThread=true; 
+        }
+        	System.out.println(isSameThread);
+    }
+    
+}

--- a/src/test/java/test/bug89/Bug89Test.java
+++ b/src/test/java/test/bug89/Bug89Test.java
@@ -1,0 +1,28 @@
+package test.bug89;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+
+public class Bug89Test extends SimpleBaseTest {
+
+    @Test(description = "Fix for https://github.com/cbeust/testng/issues/89")
+    public void methodsShouldBeSequential() {
+        XmlSuite s = createXmlSuite("Bug89");
+		Class [] tests = new Class[1];
+		tests[0]=C.class;
+        TestNG tng = create();
+        tng.setParallel("classes");
+        tng.setTestClasses(tests);   
+        tng.run();
+        Assert.assertTrue(B.isSameThread);
+    }
+}

--- a/src/test/java/test/bug89/C.java
+++ b/src/test/java/test/bug89/C.java
@@ -1,0 +1,14 @@
+package test.bug89;
+
+import org.testng.annotations.Test;
+
+public class C extends B{
+	 String threadC;
+	
+    @Test(enabled=false)
+    public void veryImportant() throws InterruptedException {
+    	scenario("veryImportant");
+    	threadC=""+Thread.currentThread();
+    	System.out.println(threadC);
+    }
+}

--- a/src/test/java/test/bug89/Main.java
+++ b/src/test/java/test/bug89/Main.java
@@ -1,0 +1,30 @@
+package test.bug89;
+
+import org.testng.TestNG;
+
+
+public class Main {
+	public static void main(String[] args) {
+		  withOutXml();
+		  withXml();
+	}
+	
+	@SuppressWarnings("rawtypes")
+	public static void withOutXml(){
+		   TestNG runTest = new TestNG();
+		   Class [] tests = new Class[1];
+		   tests[0]=C.class;
+		   runTest.setTestClasses(tests);
+		   runTest.setParallel("classes");
+		   runTest.setVerbose(5);
+		   runTest.run();
+	}
+	
+	@SuppressWarnings("static-access")
+	public static void withXml(){
+		   TestNG runTest = new TestNG();
+		   String args[]={"src/test/java/luis/samples/testng.xml"};
+		   runTest.main(args);
+	}
+	
+}

--- a/src/test/java/test/bug89/testng.xml
+++ b/src/test/java/test/bug89/testng.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Some Suite" >  
+  <test name="Some tests" verbose="10" parallel="classes" thread-count="3">
+    <classes>
+      <class name="test.bug89.C"/>
+    </classes>
+	
+  </test>
+</suite>


### PR DESCRIPTION
Where parallel = "classes" was not working correctly.

Only change done on TestRunner.java was adding   sequentialClasses.add(m.getTestClass().getRealClass()); on line 821. Dunno if we missed a pull or something but can recommit if necessary.
