### PR TITLE
Made TestNGAntTask.createArguments() protected so classes that extend it can reuse it in their's own execute() methods.

### DIFF
--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -526,7 +526,7 @@ public class TestNGAntTask extends Task {
     actOnResult(exitValue, wasKilled);
   }
 
-  private List<String> createArguments() {
+  protected List<String> createArguments() {
 	List<String> argv= Lists.newArrayList();
     addBooleanIfTrue(argv, CommandLineArgs.JUNIT, m_isJUnit);
     addBooleanIfTrue(argv, CommandLineArgs.SKIP_FAILED_INVOCATION_COUNTS, m_skipFailedInvocationCounts);

--- a/src/main/java/org/testng/remote/strprotocol/AbstractRemoteTestRunnerClient.java
+++ b/src/main/java/org/testng/remote/strprotocol/AbstractRemoteTestRunnerClient.java
@@ -99,7 +99,7 @@ public abstract class AbstractRemoteTestRunnerClient {
   }
 
   public boolean isRunning() {
-    return m_serverConnection.getMessageSender() != null;
+    return m_serverConnection != null && m_serverConnection.getMessageSender() != null;
   }
 
   /**

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -110,24 +110,6 @@ abstract public class BaseMessageSender implements IMessageSender {
 
   @Override
   public void initReceiver() throws SocketTimeoutException {
-    while (true) {
-      try {
-        initReceiver(5000);
-
-        break;
-      }
-      catch (IOException ioe) {
-        try {
-          Thread.sleep(100L);
-        }
-        catch (InterruptedException ie) {
-          // Do nothing.
-        }
-      }
-    }
-  }
-  @Override
-  public void initReceiver(int soTimeout) throws SocketTimeoutException {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
@@ -135,14 +117,27 @@ abstract public class BaseMessageSender implements IMessageSender {
     try {
       p("initReceiver on port " + m_port);
       serverSocket = new ServerSocket(m_port);
-      serverSocket.setSoTimeout(soTimeout);
+      serverSocket.setSoTimeout(5000);
 
-      Socket socket = serverSocket.accept();
-      m_inStream = socket.getInputStream();
-      m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
-      m_outStream = socket.getOutputStream();
-      m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
+      while (true) {
+        try {
+          Socket socket = serverSocket.accept();
+          m_inStream = socket.getInputStream();
+          m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
+          m_outStream = socket.getOutputStream();
+          m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
 
+          break;
+        }
+        catch (IOException ioe) {
+          try {
+            Thread.sleep(100L);
+          }
+          catch (InterruptedException ie) {
+            // Do nothing.
+          }
+        }
+      }
     }
     catch(SocketTimeoutException ste) {
       throw ste;

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -36,6 +36,7 @@ abstract public class BaseMessageSender implements IMessageSender {
 
   private ReaderThread m_readerThread;
   private boolean m_ack;
+  private boolean m_shutdownRequested;
 //  protected InputStream m_receiverInputStream;
 
   public BaseMessageSender(String host, int port, boolean ack) {
@@ -120,6 +121,9 @@ abstract public class BaseMessageSender implements IMessageSender {
       serverSocket.setSoTimeout(5000);
 
       while (true) {
+        if (m_shutdownRequested) {
+          return;
+        }
         try {
           Socket socket = serverSocket.accept();
           m_inStream = socket.getInputStream();
@@ -185,6 +189,8 @@ abstract public class BaseMessageSender implements IMessageSender {
         e.printStackTrace();
       }
     }
+
+    m_shutdownRequested = true;
   }
 
   private String m_latestAck;

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -110,6 +110,24 @@ abstract public class BaseMessageSender implements IMessageSender {
 
   @Override
   public void initReceiver() throws SocketTimeoutException {
+    while (true) {
+      try {
+        initReceiver(5000);
+
+        break;
+      }
+      catch (IOException ioe) {
+        try {
+          Thread.sleep(100L);
+        }
+        catch (InterruptedException ie) {
+          // Do nothing.
+        }
+      }
+    }
+  }
+  @Override
+  public void initReceiver(int soTimeout) throws SocketTimeoutException {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
@@ -117,27 +135,14 @@ abstract public class BaseMessageSender implements IMessageSender {
     try {
       p("initReceiver on port " + m_port);
       serverSocket = new ServerSocket(m_port);
-      serverSocket.setSoTimeout(5000);
+      serverSocket.setSoTimeout(soTimeout);
 
-      while (true) {
-        try {
-          Socket socket = serverSocket.accept();
-          m_inStream = socket.getInputStream();
-          m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
-          m_outStream = socket.getOutputStream();
-          m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
+      Socket socket = serverSocket.accept();
+      m_inStream = socket.getInputStream();
+      m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
+      m_outStream = socket.getOutputStream();
+      m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
 
-          break;
-        }
-        catch (IOException ioe) {
-          try {
-            Thread.sleep(100L);
-          }
-          catch (InterruptedException ie) {
-            // Do nothing.
-          }
-        }
-      }
     }
     catch(SocketTimeoutException ste) {
       throw ste;

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -37,6 +37,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   private ReaderThread m_readerThread;
   private boolean m_ack;
   private boolean m_shutdownRequested;
+  private ServerSocket m_serverSocket;
 //  protected InputStream m_receiverInputStream;
 
   public BaseMessageSender(String host, int port, boolean ack) {
@@ -97,6 +98,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   }
 
   private int m_serial = 0;
+  private ServerSocket _serverSocket;
 
   @Override
   public void sendAck() {
@@ -114,18 +116,17 @@ abstract public class BaseMessageSender implements IMessageSender {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
-    ServerSocket serverSocket;
     try {
       p("initReceiver on port " + m_port);
-      serverSocket = new ServerSocket(m_port);
-      serverSocket.setSoTimeout(5000);
+      m_serverSocket = new ServerSocket(m_port);
+      m_serverSocket.setSoTimeout(5000);
 
       while (true) {
         if (m_shutdownRequested) {
           return;
         }
         try {
-          Socket socket = serverSocket.accept();
+          Socket socket = m_serverSocket.accept();
           m_inStream = socket.getInputStream();
           m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
           m_outStream = socket.getOutputStream();
@@ -185,6 +186,19 @@ abstract public class BaseMessageSender implements IMessageSender {
       }
     }
     catch(IOException e) {
+      if(m_debug) {
+        e.printStackTrace();
+      }
+    }
+
+    try
+    {
+      if (null != m_serverSocket)
+      {
+        m_serverSocket.close();
+      }
+    }
+    catch (Exception e) {
       if(m_debug) {
         e.printStackTrace();
       }

--- a/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
@@ -10,17 +10,12 @@ public interface IMessageSender {
 
   /**
    * Initialize the receiver.
-   * Method will try to initialize receiver for the indefinite amount of time.
+   *
+   * @throws SocketException This exception will be thrown if a connection
+   * to the remote TestNG instance could not be established after ten
+   * seconds.
    */
   void initReceiver() throws SocketTimeoutException;
-
-  /**
-   * @param soTimeout
-   * @throws SocketException This exception will be thrown if a connection
-   * to the remote TestNG instance could not be established after soTimeout
-   * milliseconds.
-   */
-  void initReceiver(int soTimeout) throws SocketTimeoutException;
 
   void sendMessage(IMessage message) throws Exception;
 

--- a/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
@@ -10,12 +10,17 @@ public interface IMessageSender {
 
   /**
    * Initialize the receiver.
-   *
-   * @throws SocketException This exception will be thrown if a connection
-   * to the remote TestNG instance could not be established after ten
-   * seconds.
+   * Method will try to initialize receiver for the indefinite amount of time.
    */
   void initReceiver() throws SocketTimeoutException;
+
+  /**
+   * @param soTimeout
+   * @throws SocketException This exception will be thrown if a connection
+   * to the remote TestNG instance could not be established after soTimeout
+   * milliseconds.
+   */
+  void initReceiver(int soTimeout) throws SocketTimeoutException;
 
   void sendMessage(IMessage message) throws Exception;
 


### PR DESCRIPTION
Made TestNGAntTask.createArguments() protected so classes that extend it can reuse it in their's own execute() methods. Need behind this is the following: we have custom ant task CustomTestNGAntTask that extends TestNGAntTask and does bunch of preparation work before calling parent class. I wish I had an option to contribute to TestNG command arguments without overriding TestNGAntTask.execute() and reimplementing the same logic again.  

My goal it to be able to run TestNGAntTask with m_mainClass=org.testng.remote.RemoteTestNG and be able to pass all needed params.
