### PR TITLE
Fix testng-eclipse issue #48: testng-eclipse will be hang if run RemoteTestNG with error argument.

### DIFF
--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -113,33 +113,24 @@ abstract public class BaseMessageSender implements IMessageSender {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
-    ServerSocket serverSocket;
+    ServerSocket serverSocket = null;
     try {
       p("initReceiver on port " + m_port);
       serverSocket = new ServerSocket(m_port);
       serverSocket.setSoTimeout(5000);
 
-      while (true) {
-        try {
-          Socket socket = serverSocket.accept();
-          m_inStream = socket.getInputStream();
-          m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
-          m_outStream = socket.getOutputStream();
-          m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
-
-          break;
-        }
-        catch (IOException ioe) {
-          try {
-            Thread.sleep(100L);
-          }
-          catch (InterruptedException ie) {
-            // Do nothing.
-          }
-        }
-      }
+	  Socket socket = serverSocket.accept();
+	  m_inStream = socket.getInputStream();
+	  m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
+	  m_outStream = socket.getOutputStream();
+	  m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
     }
     catch(SocketTimeoutException ste) {
+      try {
+		serverSocket.close();
+	  } catch (IOException e) {
+		  // ignore
+	  }
       throw ste;
     }
     catch (IOException ioe) {


### PR DESCRIPTION
Hi cbeust

I had Fix testng-eclipse issue #48.
I found that the issue occurs because the changes of testng issue #102.

Change file list:
testng: src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
testng-eclipse: src/main/org/testng/eclipse/ui/TestRunnerViewPart.java

Brs
Cen
