### PR TITLE
Properly escape HTML entities in test failure messages

### DIFF
--- a/src/main/java/org/testng/reporters/HtmlHelper.java
+++ b/src/main/java/org/testng/reporters/HtmlHelper.java
@@ -26,4 +26,15 @@ public class HtmlHelper {
     }
     return stylesheetFile;
   }
+
+  public static String escapeCDATA(String cdata) {
+    String escaped = null;
+    if (cdata != null) {
+      escaped = cdata.replace("&", "&amp;")
+              .replace("<", "&lt;")
+              .replace("\"", "&quot;")
+              .replace("'", "&#39;");
+    }
+    return escaped;
+  }
 }

--- a/src/main/java/org/testng/reporters/jq/SuitePanel.java
+++ b/src/main/java/org/testng/reporters/jq/SuitePanel.java
@@ -2,6 +2,7 @@ package org.testng.reporters.jq;
 
 import org.testng.ISuite;
 import org.testng.ITestResult;
+import org.testng.reporters.HtmlHelper;
 import org.testng.reporters.XMLStringBuffer;
 
 import java.util.List;
@@ -83,7 +84,7 @@ public class SuitePanel extends BasePanel {
     if (tr.getStatus() != ITestResult.SUCCESS && tr.getThrowable() != null) {
       StringBuilder stackTrace = new StringBuilder();
       stackTrace.append("<b>\"")
-              .append(tr.getThrowable().getMessage())
+              .append(HtmlHelper.escapeCDATA(tr.getThrowable().getMessage()))
               .append("\"</b>")
               .append("<br>");
       for (StackTraceElement str : tr.getThrowable().getStackTrace()) {


### PR DESCRIPTION
The HTML reports do not properly escape special characters in failure messages, which can lead to problems similar to those fixed with commit 527187ef0423849510efcc577b1f033352d760dd.
