### PR TITLE
Improve the parameter test in method level (Rebase change: Parameters can now be specified in <include> tags.)

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -1,13 +1,14 @@
 package org.testng;
 
 
-import org.testng.internal.ConstructorOrMethod;
-import org.testng.xml.XmlTest;
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+
+import org.testng.internal.ConstructorOrMethod;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlTest;
 
 /**
  * Describes a TestNG annotated method and the instance on which it will be invoked.
@@ -256,4 +257,28 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
    * @param test
    */
   Map<String, String> findMethodParameters(XmlTest test);
+  
+  /**
+   * Set associated XmlInclude
+   * @param xmlInclude The associated XmlInclude
+   */
+  void setXmlInclude(XmlInclude xmlInclude);
+  
+  /**
+  *
+  * @return The associated XmlInclude, if there is no associated XmlInclude, return null
+  */
+  XmlInclude getXmlInclude();
+  
+  /**
+   * Set associated XmlInclude list.
+   * @param xmlIncludeList The associated XmlInclude list
+   */
+  void setXmlIncludeList(List<XmlInclude> xmlIncludeList);
+  
+  /**
+  *
+  * @return The associated XmlInclude list, if there is no associated XmlInclude, return null
+  */
+  List<XmlInclude> getXmlIncludeList();
 }

--- a/src/main/java/org/testng/collections/ListMultiMap.java
+++ b/src/main/java/org/testng/collections/ListMultiMap.java
@@ -15,12 +15,18 @@ public class ListMultiMap<K, V> {
   private Map<K, List<V>> m_objects = Maps.newHashMap();
 
   public void put(K key, V method) {
+    put(key, method, true);
+  }
+  
+  public void put(K key, V method, boolean addNull) {
     List<V> l = m_objects.get(key);
     if (l == null) {
       l = Lists.newArrayList();
       m_objects.put(key, l);
     }
-    l.add(method);
+    if (method != null || addNull) {
+      l.add(method);
+    }
   }
 
   public List<V> get(K key) {

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -73,6 +73,8 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
   private XmlTest m_xmlTest;
   private Object m_instance;
+  private XmlInclude m_xmlInclude;
+  private List<XmlInclude> m_xmlIncludeList;
 
   /**
    * Constructs a <code>BaseTestMethod</code> TODO cquezel JavaDoc.
@@ -417,7 +419,8 @@ public abstract class BaseTestMethod implements ITestNGMethod {
           m_testClass.getRealClass().equals(other.m_testClass.getRealClass())
           && m_instance == other.getInstance();
 
-    return isEqual && getConstructorOrMethod().equals(other.getConstructorOrMethod());
+    return isEqual && getConstructorOrMethod().equals(other.getConstructorOrMethod())
+        && (m_xmlInclude == null ? other.getXmlInclude() == null : m_xmlInclude.equals(other.getXmlInclude()));
   }
 
   /**
@@ -802,15 +805,32 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     for (XmlClass xmlClass: test.getXmlClasses()) {
       if (xmlClass.getName().equals(getTestClass().getName())) {
         result.putAll(xmlClass.getParameters());
-        for (XmlInclude include : xmlClass.getIncludedMethods()) {
-          if (include.getName().equals(getMethodName())) {
-            result.putAll(include.getParameters());
-            break;
-          }
+        
+        //If use xmlclass.getIncludMethods, it maybe find a wrong xmlInclude, 
+        //due to two include could have the same name, but different parameters
+        if (m_xmlInclude != null) {
+          result.putAll(m_xmlInclude.getParameters());
         }
+        return result;
       }
     }
 
     return result;
+  }
+  
+  public void setXmlInclude(XmlInclude xmlInclude) {
+    this.m_xmlInclude = xmlInclude;
+  }
+  
+  public XmlInclude getXmlInclude() {
+      return m_xmlInclude;
+  }
+  
+  public void setXmlIncludeList(List<XmlInclude> xmlIncludeList) {
+    this.m_xmlIncludeList = xmlIncludeList;
+  }
+  
+  public List<XmlInclude> getXmlIncludeList() {
+    return this.m_xmlIncludeList;
   }
 }

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -5,6 +5,7 @@ import org.testng.IRetryAnalyzer;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
+import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlTest;
 
 import java.lang.reflect.Method;
@@ -367,5 +368,27 @@ public class ClonedMethod implements ITestNGMethod {
   @Override
   public Map<String, String> findMethodParameters(XmlTest test) {
     return Collections.emptyMap();
+  }
+
+  @Override
+  public void setXmlInclude(XmlInclude xmlInclude) {
+    // ignore
+  }
+
+  @Override
+  public XmlInclude getXmlInclude() {
+    // ignore
+    return null;
+  }
+
+  @Override
+  public void setXmlIncludeList(List<XmlInclude> xmlIncludeList) {
+    // ignore
+  }
+
+  @Override
+  public List<XmlInclude> getXmlIncludeList() {
+    // ignore
+    return null;
   }
 }

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -9,6 +9,7 @@ import org.testng.collections.Maps;
 import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.collections.Pair;
+import org.testng.xml.XmlInclude;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -69,7 +70,21 @@ public class MethodGroupsHelper {
         }
       }
       if (in) {
-        outIncludedMethods.add(tm);
+        
+        // Get the method releated xmlInclude list which defined in the xml file.
+        // Each xmlInclude will create a new ITestNGMethod instance.
+        List<XmlInclude> xmlIncludeList = tm.getXmlIncludeList();
+        if (xmlIncludeList != null && xmlIncludeList.size() > 0) {
+          // The xmlIncludeList is no longer need, remove it.
+          tm.setXmlIncludeList(null);
+          for (XmlInclude xmlInclude : xmlIncludeList) {
+            ITestNGMethod clone = tm.clone();
+            clone.setXmlInclude(xmlInclude);
+            outIncludedMethods.add(clone);
+          }
+        } else {
+          outIncludedMethods.add(tm);
+        }
       }
       else {
         outExcludedMethods.add(tm);

--- a/src/main/java/org/testng/internal/MethodInstance.java
+++ b/src/main/java/org/testng/internal/MethodInstance.java
@@ -1,13 +1,12 @@
 package org.testng.internal;
 
+import java.util.Comparator;
+
 import org.testng.IMethodInstance;
 import org.testng.ITestNGMethod;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlTest;
-
-import java.util.Comparator;
-import java.util.List;
 
 public class MethodInstance implements IMethodInstance {
   private ITestNGMethod m_method;
@@ -67,25 +66,14 @@ public class MethodInstance implements IMethodInstance {
         result = index1 - index2;
       }
       else {
-        XmlInclude include1 =
-            findXmlInclude(class1.getIncludedMethods(), o1.getMethod().getMethodName());
-        XmlInclude include2 =
-          findXmlInclude(class2.getIncludedMethods(), o2.getMethod().getMethodName());
+        XmlInclude include1 = o1.getMethod().getXmlInclude();
+        XmlInclude include2 = o2.getMethod().getXmlInclude();
         if (include1 != null && include2 != null) {
           result = include1.getIndex() - include2.getIndex();
         }
       }
 
       return result;
-    }
-
-    private XmlInclude findXmlInclude(List<XmlInclude> includedMethods, String methodName) {
-      for (XmlInclude xi : includedMethods) {
-        if (xi.getName().equals(methodName)) {
-          return xi;
-        }
-      }
-      return null;
     }
   };
 

--- a/src/main/java/org/testng/internal/XmlMethodSelector.java
+++ b/src/main/java/org/testng/internal/XmlMethodSelector.java
@@ -1,5 +1,13 @@
 package org.testng.internal;
 
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
 import org.testng.IMethodSelector;
 import org.testng.IMethodSelectorContext;
 import org.testng.ITestNGMethod;
@@ -9,14 +17,6 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
-
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * This class is the default method selector used by TestNG to determine
@@ -94,6 +94,13 @@ public class XmlMethodSelector implements IMethodSelector {
     //
     else if (includeList != null) {
       result = true;
+      
+      // Set the method releated xmlInclude list which defined in the xml file.
+      // The xmlInclude List will be used at MethodGroupsHelper.collectMethodsByGroup()
+      
+      // TODO Now, the releated xmlInclude List is temporary store in the ITestNGMethod instance.
+      // I think it is not a good design, however I have no other good solution. Need to improve it in the feature.
+      tm.setXmlIncludeList(includeList);
     }
 
     //
@@ -383,11 +390,13 @@ public class XmlMethodSelector implements IMethodSelector {
       for (ITestNGMethod m : methodClosure) {
         String methodName =
          m.getMethod().getDeclaringClass().getName() + "." + m.getMethodName();
-//        m_includedMethods.add(methodName);
-        List<XmlInclude> includeList = m_includedMethods.get(methodName);
-        XmlInclude xi = new XmlInclude(methodName);
+        // XmlInclude xi = new XmlInclude(methodName);
         // TODO: set the XmlClass on this xi or we won't get inheritance of parameters
-        m_includedMethods.put(methodName, xi);
+        // Comments: We did not need to create a new XmlInclude, the ITestNGMethod related XmlInclude 
+        // is which defined in xml file. If the XmlInclude is not defined in the xml file, the releated
+        // XmlInclude will be null.
+        m_includedMethods.put(methodName, m.getXmlInclude(), false);
+
         logInclusion("Including", "method ", methodName);
       }
     }

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -2,6 +2,13 @@ package org.testng.xml;
 
 import static org.testng.internal.Utils.isStringBlank;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
@@ -12,13 +19,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
 
 /**
  * Suite definition parser utility.
@@ -617,6 +617,7 @@ public class TestNGContentHandler extends DefaultHandler {
       m_currentInclude = new Include(attributes.getValue("name"),
           attributes.getValue("invocation-numbers"));
     } else {
+      popLocation(Location.INCLUDE);
       String name = m_currentInclude.name;
       if (null != m_currentIncludedMethods) {
         String in = m_currentInclude.invocationNumbers;
@@ -629,7 +630,6 @@ public class TestNGContentHandler extends DefaultHandler {
         for (Map.Entry<String, String> entry : m_currentInclude.parameters.entrySet()) {
           include.addParameter(entry.getKey(), entry.getValue());
         }
-
         include.setDescription(m_currentInclude.description);
         m_currentIncludedMethods.add(include);
       }
@@ -642,8 +642,6 @@ public class TestNGContentHandler extends DefaultHandler {
       else if (null != m_currentPackage) {
         m_currentPackage.getInclude().add(name);
       }
-
-      popLocation(Location.INCLUDE);
       m_currentInclude = null;
     }
   }

--- a/src/main/java/org/testng/xml/XmlInclude.java
+++ b/src/main/java/org/testng/xml/XmlInclude.java
@@ -135,5 +135,8 @@ public class XmlInclude implements Serializable {
   public void setXmlClass(XmlClass xmlClass) {
     m_xmlClass = xmlClass;
   }
-
+  
+  public void clearParameters() {
+    m_parameters.clear();
+  }
 }

--- a/src/test/java/test/parameters/MultiIncludeParameterTest.java
+++ b/src/test/java/test/parameters/MultiIncludeParameterTest.java
@@ -1,0 +1,42 @@
+package test.parameters;
+
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+
+public class MultiIncludeParameterTest extends SimpleBaseTest {
+
+  @Test
+  public void multiIncludeParameterTest() {
+    XmlSuite s = createXmlSuite("s");
+    XmlTest t = createXmlTest(s, "t");
+
+    {
+      XmlClass c1 = new XmlClass(MultiIncludeSampleTest.class.getName());
+      int index = 0;
+      XmlInclude include1 = new XmlInclude("multiIncludeTest", index++);
+      include1.addParameter("num", "1");
+      XmlInclude include2 = new XmlInclude("multiIncludeTest", index++);
+      include2.addParameter("num", "2");
+      c1.getIncludedMethods().add(include1);
+      c1.getIncludedMethods().add(include2);
+      t.getXmlClasses().add(c1);
+    }
+
+    TestNG tng = create();
+    tng.setXmlSuites(Arrays.asList(s));
+    TestListenerAdapter tla = new TestListenerAdapter();
+    tng.addListener(tla);
+    tng.run();
+
+    assertTestResultsEqual(tla.getPassedTests(), Arrays.asList("multiIncludeTest", "multiIncludeTest"));
+  }
+}

--- a/src/test/java/test/parameters/MultiIncludeSampleTest.java
+++ b/src/test/java/test/parameters/MultiIncludeSampleTest.java
@@ -1,0 +1,17 @@
+package test.parameters;
+
+import org.testng.Assert;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class MultiIncludeSampleTest {
+  
+  private int callCount = 0;
+  
+  @Parameters("num")
+  @Test
+  public void multiIncludeTest(int num) {
+    callCount++;
+    Assert.assertEquals(callCount, num);
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -113,6 +113,7 @@
       <class name="test.ReturnValueTest" />
       <class name="test.groupbug.GroupBugTest" />
       <class name="test.parameters.ShadowTest" />
+      <class name="test.parameters.MultiIncludeParameterTest" />
       <class name="test.parameters.ParameterOverrideTest" />
       <class name="test.testng234.PolymorphicFailureTest" />
       <class name="test.reports.FailedReporterTest" />


### PR DESCRIPTION
Hi Cedric,

I already reviewed your code and merge it into my commit.

My commit include one features and one penitential bug fix:

1.Feature: We can define different parameters for the same method like this:
<include name="test001">
<parameter name="test001_name" value="Storm Qi"></parameter>
</include>
<include name="test001">
<parameter name="test001_name" value="Sean Guo"></parameter>
</include>

I think this is a very interesting feature, in the past, due to there is no method level parameters, we can use other ways such as invocationCount to run the same method several times, but now, due to the different parameters for the same method, this feature is very meaningful.

IF you want to see something more about this feature, pls ref my demo proj:
https://github.com/StormAll/testng-demo
1. A potential bug, Class level parameter will cover the method level parameter

Hope this could be merged into the testng :)
