### PR TITLE
Support define multi include tags with the same method in testng.xml.

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -256,4 +256,11 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
    * @param test
    */
   Map<String, String> findMethodParameters(XmlTest test);
+  
+  /**
+   * Support multi include tags
+   * 
+   * @return the parameters found in the include tag
+   */
+  List<Map<String, String>> getMethodParameters();
 }

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -73,7 +73,9 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
   private XmlTest m_xmlTest;
   private Object m_instance;
-
+  
+  private List<Map<String, String>> realMethodParameters = Lists.newArrayList();
+  
   /**
    * Constructs a <code>BaseTestMethod</code> TODO cquezel JavaDoc.
    *
@@ -798,19 +800,34 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   @Override
   public Map<String, String> findMethodParameters(XmlTest test) {
     // Get the test+suite parameters
-    Map<String, String> result = test.getAllParameters();
-    for (XmlClass xmlClass: test.getXmlClasses()) {
-      if (xmlClass.getName().equals(getTestClass().getName())) {
-        result.putAll(xmlClass.getLocalParameters());
-        for (XmlInclude include : xmlClass.getIncludedMethods()) {
-          if (include.getName().equals(getMethodName())) {
-            result.putAll(include.getLocalParameters());
-            break;
-          }
-        }
-      }
-    }
+  	if (realMethodParameters.isEmpty()) {
+  		
+  		Map<String, String> otherParameters = test.getAllParameters();
+  		for (XmlClass xmlClass: test.getXmlClasses()) {
+  			if (xmlClass.getName().equals(getTestClass().getName())) {
+  				otherParameters.putAll(xmlClass.getLocalParameters());
+  				for (XmlInclude include : xmlClass.getIncludedMethods()) {
+  					if (include.getName().equals(getMethodName())) {
+  						Map<String, String> methodParameters = Maps.newHashMap();
+  						methodParameters.putAll(otherParameters);
+  						methodParameters.putAll(include.getLocalParameters());
+  						realMethodParameters.add(methodParameters);
+  					}
+  				}
+  				break;
+  			}
+  		}
+  		
+  		if (realMethodParameters.isEmpty()) {
+  			realMethodParameters.add(otherParameters);
+  		}
+  	}
 
-    return result;
+    return realMethodParameters.get(0);
+  }
+  
+  @Override
+  public List<Map<String, String>> getMethodParameters() {
+  	return realMethodParameters;
   }
 }

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -368,4 +368,9 @@ public class ClonedMethod implements ITestNGMethod {
   public Map<String, String> findMethodParameters(XmlTest test) {
     return Collections.emptyMap();
   }
+
+	@Override
+	public List<Map<String, String>> getMethodParameters() {
+		return Collections.EMPTY_LIST;
+	}
 }

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -442,10 +442,16 @@ public class Parameters {
       // Normal case: we have only one set of parameters coming from testng.xml
       //
       allParameterNames.putAll(methodParams.xmlParameters);
-      // Create an Object[][] containing just one row of parameters
-      Object[][] allParameterValuesArray = new Object[1][];
-      allParameterValuesArray[0] = createParameters(testMethod.getMethod(),
-          methodParams, annotationFinder, xmlSuite, ITestAnnotation.class, "@Test");
+      
+      // Create multi Object[][] containing parameters defined in the include tags.
+			List<Map<String, String>> realMethodParameters = testMethod.getMethodParameters();
+			Object[][] allParameterValuesArray = new Object[realMethodParameters.size()][];
+			for (int i = 0; i < realMethodParameters.size(); i++) {
+				methodParams.xmlParameters = realMethodParameters.get(i);
+				allParameterValuesArray[i] = createParameters(testMethod.getMethod(),
+						methodParams, annotationFinder, xmlSuite, ITestAnnotation.class,
+						"@Test");
+			}
 
       // Mark that this method needs to have at least a certain
       // number of invocations (needed later to call AfterGroups
@@ -489,7 +495,7 @@ public class Parameters {
 
   /** A parameter passing helper class. */
   public static class MethodParameters {
-    private final Map<String, String> xmlParameters;
+    private Map<String, String> xmlParameters;
     private final Method currentTestMethod;
     private final ITestContext context;
     private Object[] parameterValues;


### PR DESCRIPTION
Hi Cebust,

This pull request will support define multi include tags with the same method in testng.xml.

For example, If you have a test method "test001" need an parameter "userName", and you define a testng.xml file like following:

`<suite name="DemoTestSuite" verbose="0" >
  <parameter name="userName" value="AAA"></parameter>
  <test name="Test1">
    <classes>
      <class name="a.b.DemoTest">
        <methods>
            <include name="test001">
                <parameter name="userName" value="BBB"></parameter>
            </include>
            <include name="test001">
                <parameter name="userName" value="CCC"></parameter>
            </include>
            <include name="test001"/>
        </methods>
      </class>
    </classes>
  </test>
</suite>`

The test method "test001" will run three times with the parameters ["BBB", "CCC", "AAA"].
I think this will be a good feature for parametrization test.

Br,
Cen
