### PR TITLE
Support use different parameters to run the same method multi-times in testng.xml.

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -256,4 +256,11 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
    * @param test
    */
   Map<String, String> findMethodParameters(XmlTest test);
+  
+  /**
+   * Support multi include tags
+   * 
+   * @return the parameters found in the include tag
+   */
+  List<Map<String, String>> getMethodParameters();
 }

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -73,7 +73,9 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
   private XmlTest m_xmlTest;
   private Object m_instance;
-
+  
+  private List<Map<String, String>> realMethodParameters = Lists.newArrayList();
+  
   /**
    * Constructs a <code>BaseTestMethod</code> TODO cquezel JavaDoc.
    *
@@ -798,19 +800,34 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   @Override
   public Map<String, String> findMethodParameters(XmlTest test) {
     // Get the test+suite parameters
-    Map<String, String> result = test.getAllParameters();
-    for (XmlClass xmlClass: test.getXmlClasses()) {
-      if (xmlClass.getName().equals(getTestClass().getName())) {
-        result.putAll(xmlClass.getLocalParameters());
-        for (XmlInclude include : xmlClass.getIncludedMethods()) {
-          if (include.getName().equals(getMethodName())) {
-            result.putAll(include.getLocalParameters());
-            break;
-          }
-        }
-      }
-    }
+  	if (realMethodParameters.isEmpty()) {
+  		
+  		Map<String, String> otherParameters = test.getAllParameters();
+  		for (XmlClass xmlClass: test.getXmlClasses()) {
+  			if (xmlClass.getName().equals(getTestClass().getName())) {
+  				otherParameters.putAll(xmlClass.getLocalParameters());
+  				for (XmlInclude include : xmlClass.getIncludedMethods()) {
+  					if (include.getName().equals(getMethodName())) {
+  						Map<String, String> methodParameters = Maps.newHashMap();
+  						methodParameters.putAll(otherParameters);
+  						methodParameters.putAll(include.getLocalParameters());
+  						realMethodParameters.add(methodParameters);
+  					}
+  				}
+  				break;
+  			}
+  		}
+  		
+  		if (realMethodParameters.isEmpty()) {
+  			realMethodParameters.add(otherParameters);
+  		}
+  	}
 
-    return result;
+    return realMethodParameters.get(0);
+  }
+  
+  @Override
+  public List<Map<String, String>> getMethodParameters() {
+  	return realMethodParameters;
   }
 }

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -368,4 +368,9 @@ public class ClonedMethod implements ITestNGMethod {
   public Map<String, String> findMethodParameters(XmlTest test) {
     return Collections.emptyMap();
   }
+
+	@Override
+	public List<Map<String, String>> getMethodParameters() {
+		return Collections.EMPTY_LIST;
+	}
 }

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -445,10 +445,16 @@ public class Parameters {
       // Normal case: we have only one set of parameters coming from testng.xml
       //
       allParameterNames.putAll(methodParams.xmlParameters);
-      // Create an Object[][] containing just one row of parameters
-      Object[][] allParameterValuesArray = new Object[1][];
-      allParameterValuesArray[0] = createParameters(testMethod.getMethod(),
-          methodParams, annotationFinder, xmlSuite, ITestAnnotation.class, "@Test");
+      
+      // Create multi Object[][] containing parameters defined in the include tags.
+			List<Map<String, String>> realMethodParameters = testMethod.getMethodParameters();
+			Object[][] allParameterValuesArray = new Object[realMethodParameters.size()][];
+			for (int i = 0; i < realMethodParameters.size(); i++) {
+				methodParams.xmlParameters = realMethodParameters.get(i);
+				allParameterValuesArray[i] = createParameters(testMethod.getMethod(),
+						methodParams, annotationFinder, xmlSuite, ITestAnnotation.class,
+						"@Test");
+			}
 
       // Mark that this method needs to have at least a certain
       // number of invocations (needed later to call AfterGroups
@@ -492,7 +498,7 @@ public class Parameters {
 
   /** A parameter passing helper class. */
   public static class MethodParameters {
-    private final Map<String, String> xmlParameters;
+    private Map<String, String> xmlParameters;
     private final Method currentTestMethod;
     private final ITestContext context;
     private Object[] parameterValues;


### PR DESCRIPTION
Hi Cbeust,

This features will support use different parameters to run the same method multi-times in testng.xml.
`<class name="a.b.DemoTest">
    <methods>
        <include name="test001">
            <parameter name="userName" value="A"></parameter>
        </include>
        <include name="test001">
            <parameter name="userName" value="B></parameter>
        </include>
    </methods>
</class>`
The test method test001 will run twice use parameter value A and B.

This feature is very useful for us. I think this is also useful for others.
Could you help us to merge it.

 I implement it use the solution you said at here: https://github.com/cbeust/testng/pull/242
There are a few things I don't like in this pull request. The correct way of handling this would be to have XmlSuite/Test/Class/Include return a ListMultiMap of parameters instead of a Map, so that we can have, for example, a multi map of { "num", [1, 2] }. Then the current parameter engine would make this work magically with little changes.

Br,
Cen
