### PR TITLE
Update src/main/java/org/testng/asserts/SoftAssert.java

### DIFF
--- a/src/main/java/org/testng/asserts/SoftAssert.java
+++ b/src/main/java/org/testng/asserts/SoftAssert.java
@@ -33,7 +33,7 @@ public class SoftAssert extends Assertion {
         } else {
           sb.append(", ");
         }
-        sb.append(ae.getValue().getMessage());
+        sb.append(ae.getKey().getMessage());
       }
       throw new AssertionError(sb.toString());
     }


### PR DESCRIPTION
getMessage is null for the IAsserts created by SoftAssert.assertX(), so printing the AssertionError message is more useful.