### PR TITLE
Release parameter after use

### DIFF
--- a/src/main/java/org/testng/internal/InvokedMethod.java
+++ b/src/main/java/org/testng/internal/InvokedMethod.java
@@ -30,7 +30,7 @@ public class InvokedMethod implements Serializable, IInvokedMethod {
                        ITestResult testResult) {
     m_instance = instance;
     m_testMethod = method;
-    m_parameters = parameters;
+    m_parameters = ParameterReference.convert(parameters);
     m_isTest = isTest;
     m_isConfigurationMethod = isConfiguration;
     m_date = date;

--- a/src/main/java/org/testng/internal/ParameterReference.java
+++ b/src/main/java/org/testng/internal/ParameterReference.java
@@ -1,0 +1,67 @@
+package org.testng.internal;
+
+import java.util.concurrent.*;
+import java.lang.ref.*;
+
+public class ParameterReference {
+  private static ConcurrentHashMap<String, String> parameterSummaries = new ConcurrentHashMap<String, String>();
+  private static int OMIT_THRESHOLD = 4096;
+  private static int MAX_NOTE_LENGTH = 30;
+
+  private Object strongReference = null;
+  private SoftReference softReference;
+  private String summary;
+  private boolean tmp = false;
+
+  protected ParameterReference(Object parameter)
+  {
+    try {
+      if (parameter instanceof TestResult) {
+        summary = ((TestResult) parameter).toStringSafe();
+      } else {
+        summary = Utils.toString(parameter);
+      }
+    } catch (Exception ignored) {
+      strongReference = parameter;
+    }
+    softReference = new SoftReference(parameter);
+    if (summary == null) {
+      return;
+    }
+    int length = summary.length();
+    if (length > OMIT_THRESHOLD) {
+      StringBuilder sb = new StringBuilder(OMIT_THRESHOLD + MAX_NOTE_LENGTH);
+      sb.append(summary, 0, OMIT_THRESHOLD);
+      sb.append(" ");
+      sb.append(length - OMIT_THRESHOLD);
+      sb.append(" more bytes omitted");
+      summary = sb.toString();
+    }
+    String other = parameterSummaries.putIfAbsent(summary, summary);
+    if (other != null) {
+      summary = other;
+    }
+  }
+
+  public String toString()
+  {
+    Object reference = softReference.get();
+    if (reference != null) {
+      return reference.toString();
+    } else {
+      return summary;
+    }
+  }
+
+  protected static ParameterReference[] convert(Object ... parameters)
+  {
+    if (parameters == null) {
+      return null;
+    }
+    ParameterReference[] result = new ParameterReference[parameters.length];
+    for (int idx = 0, size = parameters.length; idx < size; ++idx) {
+      result[idx] = new ParameterReference(parameters[idx]);
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -222,27 +222,40 @@ public class TestResult implements ITestResult {
 
   @Override
   public String toString() {
-    List<String> output = Reporter.getOutput(this);
-    String result = Objects.toStringHelper(getClass())
-        .omitNulls()
-        .omitEmptyStrings()
-        .add("name", getName())
-        .add("status", toString(m_status))
-        .add("method", m_method)
-        .add("output", output != null && output.size() > 0 ? output.get(0) : null)
-        .toString();
-
-    return result;
+    return toString(null);
   }
 
-  private String toString(int status) {
+  protected String toStringSafe() {
+    return toString("UNKNOWN");
+  }
+
+  private String toString(String defaultStatus) {
+      List<String> output = Reporter.getOutput(this);
+      String result = Objects.toStringHelper(getClass())
+      .omitNulls()
+      .omitEmptyStrings()
+      .add("name", getName())
+      .add("status", toString(m_status, defaultStatus))
+      .add("method", m_method)
+      .add("output", output != null && output.size() > 0 ? output.get(0) : null)
+      .toString();
+
+      return result;
+  }
+
+  private String toString(int status, String defaultResult) {
     switch(status) {
       case SUCCESS: return "SUCCESS";
       case FAILURE: return "FAILURE";
       case SKIP: return "SKIP";
       case SUCCESS_PERCENTAGE_FAILURE: return "SUCCESS WITHIN PERCENTAGE";
       case STARTED: return "STARTED";
-      default: throw new RuntimeException();
+      default:
+        if (defaultResult == null) {
+          throw new RuntimeException();
+        } else {
+          return defaultResult;
+        }
     }
   }
 
@@ -262,7 +275,7 @@ public class TestResult implements ITestResult {
 
   @Override
   public void setParameters(Object[] parameters) {
-    m_parameters = parameters;
+    m_parameters = ParameterReference.convert(parameters);
   }
 
   @Override


### PR DESCRIPTION
Parameters saved in InvokedMethod and TestResult make them not able to
be collected after running test even when JVM is running out of memory.
The saved parameters are served as input for report which doesn't really
have to have accurate parameter string. This patch save soft reference to
parameter instead of strong reference, so when JVM is running out of
memory, the original parameter is collected, and the summary of
parameter is used instead in toString().

BTW: TestResult.java file is mixed with dos and unix line feeding. I didn't want to convert to whole file to unix as that will make diff not readable. But it's probably a good idea to do so.
