### PR TITLE
Heap overflow error fix

### DIFF
--- a/src/main/java/org/testng/reporters/XMLStringBuffer.java
+++ b/src/main/java/org/testng/reporters/XMLStringBuffer.java
@@ -328,7 +328,8 @@ public class XMLStringBuffer {
    * @return The String representation of the XML for this XMLStringBuffer.
    */
   public String toXML() {
-    return INVALID_XML_CHARS.matcher(m_buffer.toString()).replaceAll("");
+    StringBuffer sb = new StringBuffer(m_buffer.toString());
+    return INVALID_XML_CHARS.matcher(sb).replaceAll("");
   }
 
   public static void main(String[] argv) {


### PR DESCRIPTION
This commit is for a simple fix that performs the regex for invalid xml characters over a string buffer instead of the entire string at once, thus reducing the memory footprint of the operation.

Without this fix, on very large test suites with lots of data you would get something like the following even after tuning your java parameters:

```
===============================================
SM CLI TestSuite
Total tests run: 4726, Failures: 64, Skips: 1028
Configuration Failures: 2, Skips: 0
===============================================

Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
    at java.util.Arrays.copyOf(Arrays.java:2367)
    at java.lang.AbstractStringBuilder.expandCapacity(AbstractStringBuilder.java:130)
    at java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:114)
    at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:480)
    at java.lang.StringBuffer.append(StringBuffer.java:309)
    at java.util.regex.Matcher.appendReplacement(Matcher.java:839)
    at java.util.regex.Matcher.replaceAll(Matcher.java:906)
    at org.testng.reporters.XMLStringBuffer.toXML(XMLStringBuffer.java:327)
    at org.testng.reporters.XMLReporter.generateReport(XMLReporter.java:66)
    at org.testng.TestNG.generateReports(TestNG.java:1089)
    at org.testng.TestNG.run(TestNG.java:1048)
    at org.testng.TestNG.privateMain(TestNG.java:1338)
    at org.testng.TestNG.main(TestNG.java:1307)
```
