### PR TITLE
Remove useless config method in testng-failed.xml

### DIFF
--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -18,11 +18,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Stack;
-import java.util.Properties;
-import java.util.HashMap;
-import java.util.Set;
 
 /**
  * Suite definition parser utility.
@@ -55,7 +51,8 @@ public class TestNGContentHandler extends DefaultHandler {
     SUITE,
     TEST,
     CLASS,
-    INCLUDE
+    INCLUDE,
+    EXCLUDE
   }
   private Stack<Location> m_locations = new Stack<Location>();
 
@@ -578,15 +575,7 @@ public class TestNGContentHandler extends DefaultHandler {
       xmlInclude(true, attributes);
     }
     else if ("exclude".equals(qName)) {
-      if (null != m_currentExcludedMethods) {
-        m_currentExcludedMethods.add(name);
-      }
-      else if (null != m_currentRuns) {
-        m_currentExcludedGroups.add(name);
-      }
-      else if (null != m_currentPackage) {
-        m_currentPackage.getExclude().add(name);
-      }
+      xmlExclude(true, attributes);
     }
     else if ("parameter".equals(qName)) {
       String value = expandValue(attributes.getValue("value"));
@@ -653,6 +642,24 @@ public class TestNGContentHandler extends DefaultHandler {
 
       popLocation(Location.INCLUDE);
       m_currentInclude = null;
+    }
+  }
+
+  private void xmlExclude(boolean start, Attributes attributes) {
+    if (start) {
+      m_locations.push(Location.EXCLUDE);
+      String name = attributes.getValue("name");
+      if (null != m_currentExcludedMethods) {
+        m_currentExcludedMethods.add(name);
+      }
+      else if (null != m_currentRuns) {
+        m_currentExcludedGroups.add(name);
+      }
+      else if (null != m_currentPackage) {
+        m_currentPackage.getExclude().add(name);
+      }
+    } else {
+      popLocation(Location.EXCLUDE);
     }
   }
 
@@ -724,6 +731,8 @@ public class TestNGContentHandler extends DefaultHandler {
     }
     else if ("include".equals(qName)) {
       xmlInclude(false, null);
+    } else if ("exclude".equals(qName)){
+      xmlExclude(false, null);
     }
   }
 


### PR DESCRIPTION
Hi Beust,

Currently, when we run a testng suite like this:

```
@BeforeClass
public void beforeClass(){
    System.err.println("Before class");
}

@BeforeSuite
public void beforeSuite(){
    System.err.println("beforeSuite");
}

@BeforeMethod
public void beforeMethod(){
    System.err.println("beforeMethod");
}
@Test
public void test1(){
    int a = 1/0;
}
```

The test case will fail and final testng-failed.xml looks like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
<suite name="Failed suite [Failed suite [xx]]">
  <test name="ggsdfd(failed)(failed)" preserve-order="true">
    <classes>
      <class name="MockTest">
        <methods>
          <include name="test1"/>
          <include name="beforeClass"/>
          <include name="beforeMethod"/>
          <include name="beforeSuite"/>
        </methods>
      </class> <!-- MockTest -->
    </classes>
  </test> <!-- ggsdfd(failed)(failed) -->
</suite> <!-- Failed suite [Failed suite [xx]] -->
```

The config method was added in this file too,I dont know why we need this.

My patch is reduce those config methods.

Look forward for your reply.

Br,
Tim
