### PR TITLE
Adding the Java 8 Compatibility badge to TestNG

### DIFF
--- a/README
+++ b/README
@@ -6,5 +6,8 @@ not to include the external jar files in order to keep the size down.
 
 If you want to build TestNG, please sync to the GitHub repository at http://github.com/cbeust/testng.
 
+TestNG is Java 8 Compatible
+![Compatibility Badge](https://java.net/downloads/adoptopenjdk/compat.svg)
+
 --
 The TestNG team


### PR DESCRIPTION
Amended the README file to apply the Java 8 Compatibility duke to it.

See TestNG included among other opensource projects: https://java.net/projects/adoptopenjdk/pages/TestingJava8#Java_8_and_Open_Source