### PR TITLE
fixed ignore of null message in assertNotEquals methods

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -490,11 +490,24 @@ public class Assert {
     fail(formatted + ASSERT_LEFT + expected + ASSERT_MIDDLE + actual + ASSERT_RIGHT);
   }
 
-  static private void failNotEquals(Object actual , Object expected, String message ) {
-    fail(format(actual, expected, message));
+  static private void failEquals(Object actual , String message ) {
+    fail(formatEquals(actual, message));
   }
 
-  static String format(Object actual, Object expected, String message) {
+  static private void failNotEquals(Object actual , Object expected, String message ) {
+	fail(formatNotEquals(actual, expected, message));
+  }
+  
+  static String formatEquals(Object actual, String message) {
+    String formatted = "";
+    if (null != message) {
+      formatted = message + " ";
+    }
+
+    return formatted + "both should not have the same value " + ASSERT_LEFT + actual + ASSERT_RIGHT;
+  }
+  
+  static String formatNotEquals(Object actual, Object expected, String message) {
     String formatted = "";
     if (null != message) {
       formatted = message + " ";
@@ -851,7 +864,7 @@ public class Assert {
     }
 
     if (fail) {
-      Assert.fail(message);
+      failEquals(actual1, message);
     }
   }
 
@@ -925,7 +938,7 @@ public class Assert {
     }
 
     if (fail) {
-      Assert.fail(message);
+      failEquals(actual1, message);
     }
   }
 
@@ -943,7 +956,7 @@ public class Assert {
     }
 
     if (fail) {
-      Assert.fail(message);
+      failEquals(actual1, message);
     }
   }
 


### PR DESCRIPTION
Unlike other methods (eg. assertEquals) the assertNotEquals methods are not providing default "fail" message if none was explicitly provided.

```
public static void assertNotEquals(Object actual1, Object actual2, String message) {
    boolean fail = false;
    try {
      Assert.assertEquals(actual1, actual2);
      fail = true;
    } catch (AssertionError e) {
    }

    if (fail) {
      Assert.fail(message);
    }
}
```

I have provided the solution in my forked project, and hopefully it will be included in the master project, although this is my first GitHub contribution.
