### PR TITLE
Fixed invoker to run @AfterMethod with lastTimeOnly=true on the last run

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -165,6 +165,15 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
   void setInvocationCount(int count);
 
   /**
+   * @return the total number of thimes this method needs to be invoked, including possible
+   *         clones of this method - this is relevant when threadPoolSize is bigger than 1
+   *         where each clone of this method is only invoked once individually, i.e.
+   *         {@link org.testng.ITestNGMethod#getInvocationCount()} would always return 1.
+  */
+  int getTotalInvocationCount();
+  void setTotalInvocationCount(int count);
+
+  /**
    * @return the success percentage for this method (between 0 and 100).
    */
   int getSuccessPercentage();

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -345,6 +345,22 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   }
 
   /**
+   * {@inheritDoc}
+   * @return the number of times this method or one of its clones must be invoked.
+  */
+  @Override
+  public int getTotalInvocationCount() {
+    return 1;
+  }
+
+  /**
+   * No-op.
+   */
+  @Override
+  public void setTotalInvocationCount(int count) {
+  }
+
+    /**
    * {@inheritDoc} Default value for successPercentage.
    */
   @Override

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -19,6 +19,7 @@ public class ClonedMethod implements ITestNGMethod {
   transient private Method m_javaMethod;
   private String m_id;
   private int m_currentInvocationCount;
+  private int m_totalInvocationCount;
   private long m_date;
 
   private List<Integer> m_invocationNumbers = Lists.newArrayList();
@@ -102,6 +103,11 @@ public class ClonedMethod implements ITestNGMethod {
   @Override
   public int getInvocationCount() {
     return 1;
+  }
+
+  @Override
+  public int getTotalInvocationCount() {
+    return m_totalInvocationCount;
   }
 
   @Override
@@ -258,6 +264,11 @@ public class ClonedMethod implements ITestNGMethod {
   }
 
   @Override
+  public void setTotalInvocationCount(int count) {
+      m_totalInvocationCount = count;
+  }
+
+    @Override
   public void setMissingGroup(String group) {
   }
 

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -850,7 +850,7 @@ public class Invoker implements IInvoker {
         // If we have parameters, set the boolean if we are about to run
         // the last invocation
         if (tm.getParameterInvocationCount() > 0) {
-          isLast = current == tm.getParameterInvocationCount();
+          isLast = current == tm.getParameterInvocationCount() * tm.getInvocationCount();
         }
         // If we have invocationCount > 1, set the boolean if we are about to
         // run the last invocation

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -850,12 +850,12 @@ public class Invoker implements IInvoker {
         // If we have parameters, set the boolean if we are about to run
         // the last invocation
         if (tm.getParameterInvocationCount() > 0) {
-          isLast = current == tm.getParameterInvocationCount() * tm.getInvocationCount();
+          isLast = current == tm.getParameterInvocationCount() * tm.getTotalInvocationCount();
         }
         // If we have invocationCount > 1, set the boolean if we are about to
         // run the last invocation
-        else if (tm.getInvocationCount() > 1) {
-          isLast = current == tm.getInvocationCount();
+        else if (tm.getTotalInvocationCount() > 1) {
+          isLast = current == tm.getTotalInvocationCount();
         }
         if (! cm.isLastTimeOnly() || (cm.isLastTimeOnly() && isLast)) {
           result.add(m);

--- a/src/main/java/org/testng/internal/TestNGMethod.java
+++ b/src/main/java/org/testng/internal/TestNGMethod.java
@@ -29,6 +29,7 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
   private static final long serialVersionUID = -1742868891986775307L;
   private int m_threadPoolSize = 0;
   private int m_invocationCount = 1;
+  private int m_totalInvocationCount = m_invocationCount;
   private int m_successPercentage = 100;
 
   /**
@@ -56,6 +57,11 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
   @Override
   public int getInvocationCount() {
     return m_invocationCount;
+  }
+
+  @Override
+  public int getTotalInvocationCount() {
+    return m_totalInvocationCount;
   }
 
   /**
@@ -96,6 +102,7 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
         m_successPercentage = testAnnotation.getSuccessPercentage();
 
         setInvocationCount(testAnnotation.getInvocationCount());
+        setTotalInvocationCount(testAnnotation.getInvocationCount());
         setThreadPoolSize(testAnnotation.getThreadPoolSize());
         setAlwaysRun(testAnnotation.getAlwaysRun());
         setDescription(findDescription(testAnnotation, xmlTest));
@@ -158,7 +165,12 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
     m_invocationCount= counter;
   }
 
-  /**
+  @Override
+  public void setTotalInvocationCount(int count) {
+    m_totalInvocationCount = count;
+  }
+
+    /**
    * Clones the current <code>TestNGMethod</code> and its @BeforeMethod and @AfterMethod methods.
    * @see org.testng.internal.BaseTestMethod#clone()
    */
@@ -185,6 +197,7 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
     clone.setEnabled(getEnabled());
     clone.setParameterInvocationCount(getParameterInvocationCount());
     clone.setInvocationCount(getInvocationCount());
+    clone.setTotalInvocationCount(getTotalInvocationCount());
     clone.m_successPercentage = getSuccessPercentage();
     clone.setTimeOut(getTimeOut());
     clone.setRetryAnalyzer(getRetryAnalyzer());

--- a/src/test/java/test/lasttimeonly/LastTimeOnly.java
+++ b/src/test/java/test/lasttimeonly/LastTimeOnly.java
@@ -1,0 +1,65 @@
+package test.lasttimeonly;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class LastTimeOnly {
+
+    private int count = 1;
+
+    public List<Integer> result = new LinkedList<Integer>();
+
+    @BeforeMethod(firstTimeOnly = true)
+    public void setUp() throws Exception {
+        result.clear();
+        result.add(0);
+        assertSort();
+    }
+
+    @AfterMethod(lastTimeOnly = true)
+    public void tearDown() throws Exception {
+        result.add(Integer.MAX_VALUE);
+        assertSort();
+    }
+
+    @Test(invocationCount = 10)
+    public void testCount() throws Exception {
+        result.add(count++);
+        assertSort();
+    }
+
+    @DataProvider(name = "test1")
+    public Object[][] createData1() {
+        return new Object[][]{
+                {"Cedric", 36},
+                {"Anne", 37},
+        };
+    }
+
+    @Test(invocationCount = 5, dataProvider = "test1")
+    public void testDataProviderAndCount(String n1, Integer n2) {
+        result.add(count++);
+        assertSort();
+    }
+
+    @Test(dataProvider = "test1")
+    public void testDataProvider(String n1, Integer n2) {
+        result.add(count++);
+        assertSort();
+    }
+
+    private void assertSort() {
+
+        int last = Integer.MIN_VALUE;
+        for (int i : result) {
+            if (!(last < i)) throw new RuntimeException("List not sorted");
+            last = i;
+        }
+
+    }
+}

--- a/src/test/java/test/lasttimeonly/LastTimeOnlyTest.java
+++ b/src/test/java/test/lasttimeonly/LastTimeOnlyTest.java
@@ -1,0 +1,17 @@
+package test.lasttimeonly;
+
+import org.testng.annotations.Test;
+import test.BaseTest;
+
+import static org.testng.Assert.assertEquals;
+
+public class LastTimeOnlyTest extends BaseTest {
+
+    @Test
+    public void testLastTimeOnly() throws Exception {
+        addClass(LastTimeOnly.class);
+        run();
+        assertEquals(getFailedTests().size(), 0);
+        assertEquals(getPassedTests().size(), 3);
+    }
+}


### PR DESCRIPTION
This fixes the bug which is described in https://github.com/cbeust/testng/issues/425
Also, I added a test to check for this issue.

This bug was related to issue https://github.com/cbeust/testng/issues/426 : After the fix, each thread invoces methods annotated with first time only and last time only exactly once. Before attempting to fix this, I wanted to await some feedback if this behavior is desired.