### PR TITLE
Selecting methods in ClassMethodMap (used to determine when to run AfterClass methods) fixed.

### DIFF
--- a/src/main/java/org/testng/ClassMethodMap.java
+++ b/src/main/java/org/testng/ClassMethodMap.java
@@ -1,8 +1,8 @@
 package org.testng;
 
+import org.testng.internal.RunInfo;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
-import org.testng.internal.XmlMethodSelector;
 
 import java.util.List;
 import java.util.Map;
@@ -23,12 +23,11 @@ public class ClassMethodMap {
   private Map<ITestClass, Set<Object>> m_beforeClassMethods = Maps.newHashMap();
   private Map<ITestClass, Set<Object>> m_afterClassMethods = Maps.newHashMap();
 
-  public ClassMethodMap(List<ITestNGMethod> methods, XmlMethodSelector xmlMethodSelector) {
+  public ClassMethodMap(List<ITestNGMethod> methods, RunInfo runInfo) {
     for (ITestNGMethod m : methods) {
-      // Only add to the class map methods that are included in the
-      // method selector. We can pass a null context here since the selector
-      // should already have been initialized
-      if (! xmlMethodSelector.includeMethod(null, m, true)) continue;
+      // Using RunInfo here is consistent with method selection in TestMethodWorker
+      //See https://github.com/cbeust/testng/issues/440
+      if (! runInfo.includeMethod(m, true)) continue;
 
       Object instance = m.getInstance();
       List<ITestNGMethod> l = m_classMap.get(instance);

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -484,7 +484,7 @@ public class TestRunner
                                                                 m_annotationFinder,
                                                                 false /* unique */,
                                                                 m_excludedMethods);
-    m_classMethodMap = new ClassMethodMap(testMethods, m_xmlMethodSelector);
+    m_classMethodMap = new ClassMethodMap(testMethods, m_runInfo);
 
     m_afterXmlTestMethods = MethodHelper.collectAndOrderMethods(afterXmlTestMethods,
                                                               false /* forTests */,


### PR DESCRIPTION
Fix for: https://github.com/cbeust/testng/issues/440