### PR TITLE
Fix Invoker.injectParameters() vararg handling

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1341,7 +1341,8 @@ public class Invoker implements IInvoker {
     }
 
     // beyond this, numValues <= numParams
-    for (Class<?> cls : method.getParameterTypes()) {
+    for (int paramIndex = 0; paramIndex < numParams; ++paramIndex) {
+      Class<?> cls = method.getParameterTypes()[paramIndex];
       Annotation[] annotations = method.getParameterAnnotations()[i];
       boolean noInjection = false;
       for (Annotation a : annotations) {
@@ -1355,7 +1356,9 @@ public class Invoker implements IInvoker {
         vResult.add(injected);
       } else {
         try {
-          if (method.isVarArgs()) vResult.add(parameterValues);
+          if (paramIndex + 1 == numParams && method.isVarArgs()) {
+              vResult.add(Arrays.copyOfRange(parameterValues, i, parameterValues.length));
+          }
           else vResult.add(parameterValues[i++]);
         } catch (ArrayIndexOutOfBoundsException ex) {
           throw new TestNGException("The data provider is trying to pass " + numValues


### PR DESCRIPTION
# Problem

Data provider parameter injection doesn't work for methods with mixed non-vararg & vararg parameters
# Example

``` java
import org.testng.annotations.DataProvider;
import org.testng.annotations.Test;

import java.util.Arrays;

import static org.testng.Assert.assertEquals;
import static org.testng.Assert.fail;

public class VarargsDemoTest {
    // works fine; ugly & error-prone code
    @Test(dataProvider = "testDataProvider")
    public void testService1(String... testData) {
        if (testData.length == 0) {
            fail("Test data is empty");
        }
        final String query = testData[0];
        final String[] expectedResults = Arrays.copyOfRange(testData, 1, testData.length);
        for (int i = 0; i < expectedResults.length; ++i) {
            assertEquals(processQuery(query, i), expectedResults[i]);
        }
    }

    // works fine, params (number of results) are hardcoded
    @Test(dataProvider = "testDataProvider")
    public void testService2(String query, String expected0, String expected1) {
        assertEquals(processQuery(query, 0), expected0);
        assertEquals(processQuery(query, 1), expected1);
    }

    // doesn't work for now (works with patch)
    @Test(dataProvider = "testDataProvider")
    public void testService3(String query, String... expectedResults) {
        for (int i = 0; i < expectedResults.length; ++i) {
            assertEquals(processQuery(query, i), expectedResults[i]);
        }
    }

    @DataProvider(name = "testDataProvider")
    public Object[][] testDataProvider() {
        return new Object[][] {
                new String[]{ "abc", "abc_result#0", "abc_result#1" },
                new String[]{ "cba", "cba_result#0", "cba_result#1" },
        };
    }

    private String processQuery(String query, int resultNum) {
        return query + "_result#" + resultNum;
    }
}
```
