### PR TITLE
Fix Invoker.injectParameters(): vararg handling; injection handling

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1329,9 +1329,8 @@ public class Invoker implements IInvoker {
       ITestContext context, ITestResult testResult)
     throws TestNGException {
     List<Object> vResult = Lists.newArrayList();
-    int i = 0;
-    int numValues = parameterValues.length;
-    int numParams = method.getParameterTypes().length;
+    final int numValues = parameterValues.length;
+    final int numParams = method.getParameterTypes().length;
 
     if (numValues > numParams && ! method.isVarArgs()) {
       throw new TestNGException("The data provider is trying to pass " + numValues
@@ -1341,8 +1340,10 @@ public class Invoker implements IInvoker {
     }
 
     // beyond this, numValues <= numParams
-    for (Class<?> cls : method.getParameterTypes()) {
-      Annotation[] annotations = method.getParameterAnnotations()[i];
+    int valueIndex = 0;
+    for (int paramIndex = 0; paramIndex < numParams; ++paramIndex) {
+      Class<?> cls = method.getParameterTypes()[paramIndex];
+      Annotation[] annotations = method.getParameterAnnotations()[paramIndex];
       boolean noInjection = false;
       for (Annotation a : annotations) {
         if (a instanceof NoInjection) {
@@ -1355,8 +1356,10 @@ public class Invoker implements IInvoker {
         vResult.add(injected);
       } else {
         try {
-          if (method.isVarArgs()) vResult.add(parameterValues);
-          else vResult.add(parameterValues[i++]);
+          if (paramIndex + 1 == numParams && method.isVarArgs()) {
+              vResult.add(Arrays.copyOfRange(parameterValues, valueIndex, parameterValues.length));
+          }
+          else vResult.add(parameterValues[valueIndex++]);
         } catch (ArrayIndexOutOfBoundsException ex) {
           throw new TestNGException("The data provider is trying to pass " + numValues
               + " parameters but the method "

--- a/src/test/java/test/dataprovider/VarArgsDataProviderTest.java
+++ b/src/test/java/test/dataprovider/VarArgsDataProviderTest.java
@@ -4,16 +4,40 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class VarArgsDataProviderTest {
-  private static final String[] S = new String[] { "a", "b", "c" };
+import java.util.Arrays;
 
+public class VarArgsDataProviderTest {
   @DataProvider
   public Object[][] data() {
-    return new Object[][] { S };
+    return new Object[][] {
+      new String[] { "query1", "query1#response0", "query1#response1" },
+      new String[] { "query2", "query2#response0", "query2#response1" },
+    };
+  }
+
+  public String getResponse(String query, int responseIndex) {
+    return String.format("%s#response%d", query, responseIndex);
   }
 
   @Test(dataProvider = "data")
-  public void testWithTwoEntriesInTestToolWindow(String... o) {
-    Assert.assertEquals(o, S);
+  public void testNoVararg(String query, String response0, String response1) {
+    Assert.assertEquals(getResponse(query, 0), response0);
+    Assert.assertEquals(getResponse(query, 1), response1);
+  }
+
+  @Test(dataProvider = "data")
+  public void testVararg(String... data) {
+    String query = data[0];
+    String[] expectedResponses = Arrays.copyOfRange(data, 1, data.length);
+    for (int responseIndex = 0; responseIndex < expectedResponses.length; ++responseIndex) {
+      Assert.assertEquals(getResponse(query, responseIndex), expectedResponses[responseIndex]);
+    }
+  }
+
+  @Test(dataProvider = "data")
+  public void testMixed(String query, String... expectedResponses) {
+    for (int responseIndex = 0; responseIndex < expectedResponses.length; ++responseIndex) {
+      Assert.assertEquals(getResponse(query, responseIndex), expectedResponses[responseIndex]);
+    }
   }
 }

--- a/src/test/java/test/inject/NoInjectionTest.java
+++ b/src/test/java/test/inject/NoInjectionTest.java
@@ -13,25 +13,43 @@ import java.lang.reflect.Method;
  * @author cbeust
  */
 public class NoInjectionTest {
-
-  @DataProvider(name = "provider")
-  public Object[][] provide() throws Exception {
-      return new Object[][] { { CC.class.getMethod("f") } };
+  public void f() {
   }
 
-  @Test(dataProvider = "provider")
+  @DataProvider(name = "singleValueProvider")
+  public Object[][] provide() throws Exception {
+      return new Object[][] { { NoInjectionTest.class.getMethod("f") } };
+  }
+
+  @Test(dataProvider = "singleValueProvider")
   public void withoutInjection(@NoInjection Method m) {
       Assert.assertEquals(m.getName(), "f");
   }
 
-  @Test(dataProvider = "provider")
+  @Test(dataProvider = "singleValueProvider")
   public void withInjection(Method m) {
       Assert.assertEquals(m.getName(), "withInjection");
   }
-}
 
-class CC {
+  // Multi-injection test
+  @DataProvider
+  public Object[][] multiValuedProvider() throws NoSuchMethodException {
+    return new Object[][] {
+      { null, "some_data" }
+    };
+  }
 
-  public void f() {
+  @Test(dataProvider = "multiValuedProvider")
+  public void multiValuedTest1(@NoInjection Method providedMethod, Method thisMethod, String data) {
+    Assert.assertNull(providedMethod);
+    Assert.assertEquals(thisMethod.getName(), "multiValuedTest1");
+    Assert.assertEquals(data, "some_data");
+  }
+
+  @Test(dataProvider = "multiValuedProvider")
+  public void multiValuedTest2(Method thisMethod, @NoInjection Method providedMethod, String data) {
+    Assert.assertNull(providedMethod);
+    Assert.assertEquals(thisMethod.getName(), "multiValuedTest2");
+    Assert.assertEquals(data, "some_data");
   }
 }


### PR DESCRIPTION
I've added (actually changed existing) two tests; both fail on current version.

First (`VarArgsDataProviderTest`) is about data provider's vararg handling:
- method with no vararg parameter works
- method with the only vararg parameter works
- method with mixed not vararg and vararg parameters fails to execute

Second (`NoInjectionTest`) is about data provider & method parameter's @NoInjection annotation handling.