### PR TITLE
Fix #onAssertSuccess called after #onAssertFailure in SoftAssert

### DIFF
--- a/src/main/java/org/testng/asserts/SoftAssert.java
+++ b/src/main/java/org/testng/asserts/SoftAssert.java
@@ -14,18 +14,23 @@ public class SoftAssert extends Assertion {
   private Map<AssertionError, IAssert> m_errors = Maps.newLinkedHashMap();
 
   @Override
-  public void executeAssert(IAssert a) {
+  protected void doAssert(IAssert a) {
+    onBeforeAssert(a);
     try {
       a.doAssert();
-    } catch(AssertionError ex) {
+      onAssertSuccess(a);
+    } catch (AssertionError ex) {
       onAssertFailure(a, ex);
       m_errors.put(ex, a);
+    } finally {
+      onAfterAssert(a);
     }
   }
 
+
   public void assertAll() {
     if (! m_errors.isEmpty()) {
-      StringBuilder sb = new StringBuilder("The following asserts failed:\n");
+      StringBuilder sb = new StringBuilder("The following asserts failed:");
       boolean first = true;
       for (Map.Entry<AssertionError, IAssert> ae : m_errors.entrySet()) {
         if (first) {
@@ -33,6 +38,12 @@ public class SoftAssert extends Assertion {
         } else {
           sb.append(", ");
         }
+        sb.append("\n\t");
+        final String message = ae.getValue().getMessage();
+        if (message != null) {
+          sb.append(message).append("\t");
+        }
+        //noinspection ThrowableResultOfMethodCallIgnored
         sb.append(ae.getKey().getMessage());
       }
       throw new AssertionError(sb.toString());

--- a/src/test/java/test/assertion/SoftAssertTest.java
+++ b/src/test/java/test/assertion/SoftAssertTest.java
@@ -1,0 +1,53 @@
+package test.assertion;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.asserts.IAssert;
+import org.testng.asserts.SoftAssert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class SoftAssertTest {
+  @Test
+  public void testOnSucceedCalled() throws Exception {
+    final Collection<IAssert> succeed = new ArrayList<IAssert>();
+    final SoftAssert sa = new SoftAssert() {
+      @Override
+      public void onAssertSuccess(IAssert assertCommand) {
+        succeed.add(assertCommand);
+      }
+    };
+    sa.assertTrue(true);
+    sa.assertTrue(false);
+    Assert.assertEquals(succeed.size(), 1, succeed.toString());
+  }
+
+  @Test
+  public void testOnFailureCalled() throws Exception {
+    final Collection<IAssert> failured = new ArrayList<IAssert>();
+    final SoftAssert sa = new SoftAssert() {
+      @Override
+      public void onAssertFailure(IAssert assertCommand, AssertionError ex) {
+        failured.add(assertCommand);
+      }
+    };
+    sa.assertTrue(true);
+    sa.assertTrue(false);
+    Assert.assertEquals(failured.size(), 1, failured.toString());
+  }
+
+  @Test
+  public void testAssertAllCount() throws Exception {
+    final SoftAssert sa = new SoftAssert();
+    sa.assertTrue(true);
+    sa.assertTrue(false);
+    try {
+      sa.assertAll();
+      Assert.fail("Exception expected");
+    } catch (AssertionError e) {
+      final String message = e.getMessage();
+      Assert.assertEquals(message.split("\r?\n").length, 2, message);
+    }
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -729,6 +729,7 @@
   <test name="Assertion">
     <classes>
       <class name="test.assertion.AssertionTest"/>
+      <class name="test.assertion.SoftAssertTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Improve failure message in SoftAssert#assertAll

BTW. Another approach is do not throw exception in Assertion#doAssert, but do that in #onAssertFailure. But that is API change.