### PR TITLE
Fix an issue that data provider passes invalid parameters to test method when using a combination of fixed and var args

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1355,7 +1355,7 @@ public class Invoker implements IInvoker {
         vResult.add(injected);
       } else {
         try {
-          if (method.isVarArgs()) vResult.add(parameterValues);
+          if (method.isVarArgs() && cls.isArray()) vResult.add(parameterValues);
           else vResult.add(parameterValues[i++]);
         } catch (ArrayIndexOutOfBoundsException ex) {
           throw new TestNGException("The data provider is trying to pass " + numValues

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1355,7 +1355,7 @@ public class Invoker implements IInvoker {
         vResult.add(injected);
       } else {
         try {
-          if (method.isVarArgs() && cls.isArray()) vResult.add(parameterValues);
+          if (method.isVarArgs() && cls.isArray()) vResult.add(Arrays.copyOfRange(parameterValues, i, numValues));
           else vResult.add(parameterValues[i++]);
         } catch (ArrayIndexOutOfBoundsException ex) {
           throw new TestNGException("The data provider is trying to pass " + numValues


### PR DESCRIPTION
I encountered an issue while performing my tests, say:

``` java
@DataProvider
private Iterator\<Object[]\> testData() {
    return Arrays.asList("a", "b", "c", "d").iterator();
}

@Test(dataProvider="testData")
private void test(String fixedArg1, Object fixedArg2, String... args) {}
```

In this case, actually, the three parameters passed to test method are identically, which is `{"a", "b", "c", "d"}`, therefore resulting in a parameter conflict exception.

After investigating testng source code, the root cause for this issue is located at org.testng.internal.Invoker.java:1358

``` java
if (method.isVarArgs()) vResult.add(parameterValues);
else vResult.add(parameterValues[i++]);
```

Here, we only examine if the test method has var args, but ignore that it may have fixed args as well.
I add a examine condition that investigates if the current parameter type is an array, which can fix this issue:

``` java
if (method.isVarArgs() && cls.isArray()) vResult.add(Arrays.copyOfRange(parameterValues, i, numValues));
else vResult.add(parameterValues[i++]);
```

Please be noted that this change only takes effect under java 1.6+.

Hope you guys review this change and commit it if correct. Thanks;)
