### PR TITLE
set suitethreadpoolsize so suites can be run in parallel using maven surefire

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1579,6 +1579,12 @@ public class TestNG {
     if (defaultSuiteName != null) {
       result.suiteName = defaultSuiteName;
     }
+    
+    // the value in the map will not be an Integer since surefire-testng isn't handling this value
+    String stps = (String) cmdLineArgs.get(CommandLineArgs.SUITE_THREAD_POOL_SIZE);
+    if (stps != null) {
+      result.suiteThreadPoolSize = Integer.parseInt(stps);  // what if it isn't a number?
+    }
 
     String defaultTestName = (String) cmdLineArgs.get(CommandLineArgs.TEST_NAME);
     if (defaultTestName != null) {


### PR DESCRIPTION
set suitethreadpoolsize so suites can be run in parallel using maven surefire

maven surefire plugin is using deprecated TestNG configure method which never sets the suitethreadpoolsize.  until maven surefire uses latest TestNG configure this fix would allow running suites in parallel when running tests using the maven surefire plugin.  issue 512 would be fixed as well and addresses the issues raised below:

http://comments.gmane.org/gmane.comp.java.testng.devel/694
https://groups.google.com/forum/#!searchin/testng-users/suitethreadpoolsize/testng-users/kO3mtzuVhNA/8fhDu6GmFVEJ