### PR TITLE
testng-288 fixed incorrect tests processing order in sequential mode

### DIFF
--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -762,11 +762,15 @@ public class TestRunner
         }
 
         while (! freeNodes.isEmpty()) {
-          List<IWorker<ITestNGMethod>> runnables = createWorkers(freeNodes);
-          for (IWorker<ITestNGMethod> r : runnables) {
-            r.run();
-          }
-          graph.setStatus(freeNodes, Status.FINISHED);
+          // We should process nodes one-by-one in sequential mode, otherwise we will
+          // break the order (see issue #288)
+          List<ITestNGMethod> firstNodeList = Collections.singletonList(freeNodes.get(0));
+
+          IWorker<ITestNGMethod> runnable = createWorkers(firstNodeList).get(0);
+          runnable.run();
+
+          graph.setStatus(firstNodeList, Status.FINISHED);
+
           freeNodes = graph.getFreeNodes();
           if (debug) {
             System.out.println("Free nodes:" + freeNodes);


### PR DESCRIPTION
Testng uses incorrect topological processing mechanism while running tests in sequential mode, thus breaking the initial tests execution order. 
I didn't find an easy way to write a test for it, but here is the case (`A->B` means that A depends on B):
If tests are ordered as follows in the tests Graph:

```
TestA.testMethod1
TestA.testMethod2->TestA.testMethod1
TestB.testMethod1
TestB.testMethod2
```

Then `TestRunner` will execute them as:
Without fix:

```
TestA.testMethod1
TestB.testMethod1
TestB.testMethod2
TestA.testMethod2->TestA.testMethod1
```

With fix:

```
TestA.testMethod1
TestA.testMethod2->TestA.testMethod1
TestB.testMethod1
TestB.testMethod2
```

Use case:
Integration tests written in TestNG (e.g. database setup/teardown in beforeclass/afterclass methods)
