### PR TITLE
Fix eclipse classpath for snakeyaml jar

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,7 +9,7 @@
 	<classpathentry kind="lib" path="lib/guice-2.0.jar"/>
 	<classpathentry kind="lib" path="lib/jcommander-1.27.jar"/>
 	<classpathentry kind="lib" path="lib/bsh-2.0b4.jar"/>
-	<classpathentry kind="lib" path="lib/snakeyaml-1.6.jar" sourcepath="/Users/cbeust/.m2/repository/org/yaml/snakeyaml/1.6/snakeyaml-1.6-sources.jar"/>
+	<classpathentry kind="lib" path="lib/snakeyaml-1.12.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.10.jar"/>
 	<classpathentry kind="lib" path="lib/aopalliance-1.0.jar"/>
 	<classpathentry kind="output" path="eclipse-build"/>


### PR DESCRIPTION
As part of pull request #494, the snakeyaml.jar was updated to 1.12 but
eclipse classpath still pointed to 1.6.