### PR TITLE
Update VERSION to "6.8.22"  in Version.java

### DIFF
--- a/src/main/java/org/testng/internal/Version.java
+++ b/src/main/java/org/testng/internal/Version.java
@@ -1,7 +1,7 @@
 package org.testng.internal;
 
 public class Version {
-  public static final String VERSION = "6.8.9beta";
+  public static final String VERSION = "6.8.22";
 
   public static void displayBanner() {
     System.out.println("...\n... TestNG " + VERSION + " by Cédric Beust (cedric@beust.com)\n...\n");


### PR DESCRIPTION
update VERSION to "6.8.22" to align with the version in pom.xml, this also correct the version banner when set verbose to 2, otherwise an stale version was displayed:
```
... TestNG 6.8.9beta by Cédric Beust (cedric@beust.com)
```