### PR TITLE
Use JCommander 1.5 consistently

### DIFF
--- a/pom-test.xml
+++ b/pom-test.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.27</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
         <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.27</version>
+      <version>1.5</version>
     </dependency>
 
 	  <dependency>

--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -1,12 +1,12 @@
 package org.testng;
 
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.converters.CommaParameterSplitter;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.testng.collections.Lists;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.converters.CommaSeparatedConverter;
 
 public class CommandLineArgs {
 
@@ -135,7 +135,7 @@ public class CommandLineArgs {
 
   public static final String METHODS = "-methods";
   @Parameter(names = METHODS, description = "Comma separated of test methods",
-      splitter = CommaParameterSplitter.class)
+      converter = CommaSeparatedConverter.class)
   public List<String> commandLineMethods = new ArrayList<String>();
 
   public static final String SUITE_THREAD_POOL_SIZE = "-suitethreadpoolsize";


### PR DESCRIPTION
My IDE is badly confused by the dependency on differing versions of JCommander, so I'm just putting everything on 1.5.