### PR TITLE
Fixing Reporter.getOutput(TestResult) for EmailableReporter2.

### DIFF
--- a/src/test/java/test/reports/ReporterLogSampleTest.java
+++ b/src/test/java/test/reports/ReporterLogSampleTest.java
@@ -1,5 +1,6 @@
 package test.reports;
 
+import java.util.List;
 import org.testng.ITestResult;
 import org.testng.Reporter;
 import org.testng.TestListenerAdapter;
@@ -10,6 +11,8 @@ import test.reports.ReporterLogSampleTest.MyTestListener;
 
 @Listeners(MyTestListener.class)
 public class ReporterLogSampleTest {
+  public static volatile List<String> output;
+
   public static class MyTestListener extends TestListenerAdapter {
     @Override
     public void onTestSuccess(ITestResult result) {
@@ -21,5 +24,6 @@ public class ReporterLogSampleTest {
   @Test
   public void test1() {
     Reporter.log("Log from test method");
+    output = Reporter.getOutput();
   }
 }

--- a/src/test/java/test/reports/ReporterLogTest.java
+++ b/src/test/java/test/reports/ReporterLogTest.java
@@ -1,13 +1,14 @@
 package test.reports;
 
 import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
 import org.testng.Reporter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 
 import test.SimpleBaseTest;
 
-import java.util.List;
+import org.testng.ITestResult;
 
 /**
  * Make sure that Reporter.log() in listeners don't get discarded.
@@ -18,15 +19,27 @@ public class ReporterLogTest extends SimpleBaseTest {
   public void shouldLogFromListener() {
     TestNG tng = create(ReporterLogSampleTest.class);
     tng.run();
-    List<String> output = Reporter.getOutput();
     boolean success = false;
-    for(String s : output) {
+    for(String s : ReporterLogSampleTest.output) {
       if (s.contains("Log from listener")) {
         success = true;
         break;
       }
     }
     Assert.assertTrue(success);
-//    System.out.println(output);
+  }
+
+  @Test
+  public void we_should_be_able_to_get_output_for_specific_results() {
+    String expectedLog1 = "asdfasdf";
+    String expectedLog2 = "ffffzzzzsdf";
+    ITestResult result1 = new org.testng.internal.TestResult();
+    ITestResult result2 = new org.testng.internal.TestResult();
+    Reporter.setCurrentTestResult(result1);
+    Reporter.log(expectedLog1);
+    Reporter.setCurrentTestResult(result2);
+    Reporter.log(expectedLog2);
+    assertEquals(expectedLog1, Reporter.getOutput(result1).get(0));
+    assertEquals(expectedLog2, Reporter.getOutput(result2).get(0));
   }
 }


### PR DESCRIPTION
`Reporter.log("Something")` wasn't getting output in `emailable-report.html` as the following line always got a new `List`: https://github.com/cbeust/testng/blob/master/src/main/java/org/testng/reporters/EmailableReporter2.java#L423.