### PR TITLE
Support for custom testng file parsers through command line args

### DIFF
--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -55,6 +55,12 @@ public class CommandLineArgs {
         "names implementing ITestRunnerFactory")
   public String objectFactory;
 
+  public static final String PARSER = "-parser";
+  @Parameter(names = PARSER, description = "Semicolon separated bindings of file extensions to .class files "
+  		+ "or class names implementing IFileParser<XmlSuite>, colon is used as separator for file extension "
+  		+ "and parser implementation (ex: \"extension:fileParserClass\".")
+  public String parser;
+  
   public static final String PARALLEL= "-parallel";
   @Parameter(names = PARALLEL, description = "Parallel mode (methods, tests or classes)")
   public String parallelMode;

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -51,6 +51,7 @@ import org.testng.reporters.SuiteHTMLReporter;
 import org.testng.reporters.VerboseReporter;
 import org.testng.reporters.XMLReporter;
 import org.testng.reporters.jq.Main;
+import org.testng.xml.IFileParser;
 import org.testng.xml.Parser;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
@@ -411,6 +412,10 @@ public class TestNG {
     }
   }
 
+  private void addFileParser(String extension, IFileParser<XmlSuite> fileParser) {
+    Parser.addFileParser(extension, fileParser);
+  }
+  
   private Parser getParser(String path) {
     Parser result = new Parser(path);
     initProcessor(result);
@@ -1469,6 +1474,22 @@ public class TestNG {
       setTestSuites(cla.suiteFiles);
     }
 
+    if (cla.parser != null) {
+      String sep1 = ";";
+      String sep2 = ":";
+      String[] parserExtBindings = Utils.split(cla.parser, sep1);
+      for (String parserExtBinding : parserExtBindings) {
+        String[] parserExtPair = Utils.split(parserExtBinding, sep2);
+    	if (parserExtPair.length == 2) {
+    	  String extension = parserExtPair[0];
+    	  String parserFile = parserExtPair[1];
+    	  Class parserClass = ClassHelper.fileToClass(parserFile);
+    	  IFileParser<XmlSuite> parserInstance = ClassHelper.newInstance(parserClass);
+    	  addFileParser(extension, parserInstance);
+    	}
+      }
+    }
+    
     setSuiteThreadPoolSize(cla.suiteThreadPoolSize);
     setRandomizeSuites(cla.randomizeSuites);
   }

--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -13,6 +13,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,8 +37,17 @@ public class Parser {
   private static final IFileParser<XmlSuite> XML_PARSER =
 //      new DomXmlParser();
       new SuiteXmlParser();
-  private static final IFileParser<XmlSuite> YAML_PARSER = new YamlParser();
+//  private static final IFileParser<XmlSuite> YAML_PARSER = new YamlParser();
   private static final IFileParser<XmlSuite> DEFAULT_FILE_PARSER = XML_PARSER;
+
+  /** Parsers map, key is file extension, value corresponding file parser implementation instance. */	
+  private static Map<String, IFileParser<XmlSuite>> parsers = new HashMap<>();
+  
+  static {
+	  //default parsers
+	  parsers.put("xml", DEFAULT_FILE_PARSER);
+	  parsers.put("yaml", new YamlParser());
+  }
 
   /** The file name of the xml suite being parsed. This may be null if the Parser
    * has not been initialized with a file name. TODO CQ This member is never used. */
@@ -113,12 +123,18 @@ public class Parser {
 //  }
 
   private IFileParser getParser(String fileName) {
-    IFileParser result = DEFAULT_FILE_PARSER;
-
-    if (fileName.endsWith(".xml")) result = XML_PARSER;
-    else if (fileName.endsWith(".yaml")) result = YAML_PARSER;
-
-    return result;
+//    IFileParser result = DEFAULT_FILE_PARSER;
+//
+//    if (fileName.endsWith(".xml")) result = XML_PARSER;
+//    else if (fileName.endsWith(".yaml")) result = YAML_PARSER;
+//
+//    return result;
+	for (Map.Entry<String, IFileParser<XmlSuite>> entry : parsers.entrySet()) {
+	  if (fileName.endsWith(entry.getKey())) {
+		  return entry.getValue();
+	  }
+	}
+    return DEFAULT_FILE_PARSER;
   }
 
   /**
@@ -240,6 +256,9 @@ public class Parser {
   }
 
 
+  public static void addFileParser(String extension, IFileParser<XmlSuite> fileParser) {
+    parsers.put(extension, fileParser);
+  }
 
 }
 


### PR DESCRIPTION
Support for custom testng file parsers through command line argument -parser, it allows to use testng files following custom dtd or xsd schemas. Parser is updated to recieve custom IFileParser<XmlSuite> implementations for concrete file extensions. -parser argument value is a semicolon separated list of file extension to IFileParser<XmlSuite> implementation bindings (binding example  "xml:com.myproject.XmlParser" overrides default TestNG parser for xml files). 
If the update is accepted the next steps are TestNGAntTask update to support the same functionality and probably eclipse plugin update to support vary file extensions (it would give the freedom to write testng files with extension .suite .case etc and provide corresponding parsers for them)