### PR TITLE
Upgrade to SnakeYAML 1.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile 'org.beanshell:bsh:2.0b4'
     compile 'com.google.inject:guice:4.0:no_aop'
     compile 'com.beust:jcommander:1.48'
-    compile 'org.yaml:snakeyaml:1.12'
+    compile 'org.yaml:snakeyaml:1.15'
 
     testCompile 'org.assertj:assertj-core:2.0.0'
     testCompile 'org.testng:testng:6.9.4'

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,7 +6,7 @@
     <dependency org="junit" name="junit" rev="4.10" />
     <dependency org="org.beanshell" name="bsh" rev="2.0b4" />
     <dependency org="com.google.inject" name="guice" rev="2.0" />
-    <dependency org="org.yaml" name="snakeyaml" rev="1.12" />
+    <dependency org="org.yaml" name="snakeyaml" rev="1.15" />
     <dependency org="com.beust" name="jcommander" rev="1.48" />
   </dependencies>
 </ivy-module>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 	  <dependency>
 	    <groupId>org.yaml</groupId>
 	    <artifactId>snakeyaml</artifactId>
-	    <version>1.12</version>
+	    <version>1.15</version>
       <optional>true</optional>
 	  </dependency>
 

--- a/src/main/java/org/testng/internal/Yaml.java
+++ b/src/main/java/org/testng/internal/Yaml.java
@@ -7,7 +7,6 @@ import org.testng.xml.XmlPackage;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 import org.xml.sax.SAXException;
-import org.yaml.snakeyaml.Loader;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -24,7 +23,7 @@ import java.util.Map;
 
 /**
  * YAML support for TestNG.
- * 
+ *
  * @author Cedric Beust <cedric@beust.com>
  */
 public class Yaml {
@@ -49,9 +48,7 @@ public class Yaml {
       constructor.addTypeDescription(testDescription);
     }
 
-    Loader loader = new Loader(constructor);
-
-    org.yaml.snakeyaml.Yaml y = new org.yaml.snakeyaml.Yaml(loader);
+    org.yaml.snakeyaml.Yaml y = new org.yaml.snakeyaml.Yaml(constructor);
     if (is == null) is = new FileInputStream(new File(filePath));
     XmlSuite result = (XmlSuite) y.load(is);
 
@@ -172,7 +169,7 @@ public class Yaml {
         toYaml(result, sp2 + "  - ", xp);
       }
     }
-    
+
     if (t.getXmlClasses().size() > 0) {
       result.append(sp2).append("classes:\n");
       for (XmlClass xc : t.getXmlClasses())  {


### PR DESCRIPTION
For security reasons, I like to see parser dependencies kept up-to-date (especially since this upgrade requires code changes, meaning that clients can't just override the version).