### PR TITLE
Remove Comparable from `ITestNGMethod`

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -16,7 +16,7 @@ import java.util.Map;
  *
  * @author Cedric Beust, May 3, 2004
  */
-public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
+public interface ITestNGMethod extends Serializable, Cloneable {
 
   /**
    * @return The real class on which this method was declared

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -138,24 +138,6 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     m_testClass = tc;
   }
 
-  @Override
-  public int compareTo(Object o) {
-    int result = -2;
-    Class<?> thisClass = getRealClass();
-    Class<?> otherClass = ((ITestNGMethod) o).getRealClass();
-    if (this == o) {
-      result = 0;
-    } else if (thisClass.isAssignableFrom(otherClass)) {
-      result = -1;
-    } else if (otherClass.isAssignableFrom(thisClass)) {
-      result = 1;
-    } else if (equals(o)) {
-      result = 0;
-    }
-
-    return result;
-  }
-
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -297,22 +297,6 @@ public class ClonedMethod implements ITestNGMethod {
   }
 
   @Override
-  public int compareTo(Object o) {
-    int result = -2;
-    Class<?> thisClass = getRealClass();
-    Class<?> otherClass = ((ITestNGMethod) o).getRealClass();
-    if (thisClass.isAssignableFrom(otherClass)) {
-      result = -1;
-    } else if (otherClass.isAssignableFrom(thisClass)) {
-      result = 1;
-    } else if (equals(o)) {
-      result = 0;
-    }
-
-    return result;
-  }
-
-  @Override
   public ClonedMethod clone() {
     return new ClonedMethod(m_method, m_javaMethod);
   }

--- a/src/main/java/org/testng/internal/MethodInheritance.java
+++ b/src/main/java/org/testng/internal/MethodInheritance.java
@@ -1,6 +1,7 @@
 package org.testng.internal;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -9,6 +10,24 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 
 public class MethodInheritance {
+
+  private static final Comparator<ITestNGMethod> COMPARATOR = new Comparator<ITestNGMethod>() {
+    @Override
+    public int compare(ITestNGMethod o1, ITestNGMethod o2) {
+      int result = -2;
+      Class<?> thisClass = o1.getRealClass();
+      Class<?> otherClass = o2.getRealClass();
+      if (thisClass.isAssignableFrom(otherClass)) {
+        result = -1;
+      } else if (otherClass.isAssignableFrom(thisClass)) {
+        result = 1;
+      } else if (o1.equals(o2)) {
+        result = 0;
+      }
+      return result;
+    }
+  };
+
   /**
    * Look in map for a class that is a superclass of methodClass
    */
@@ -153,7 +172,7 @@ public class MethodInheritance {
   private static void sortMethodsByInheritance(List<ITestNGMethod> methods,
       boolean baseClassToChild)
   {
-    Collections.sort(methods);
+    Collections.sort(methods, COMPARATOR);
     if (! baseClassToChild) {
       Collections.reverse(methods);
     }

--- a/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -253,11 +253,6 @@ public class MethodInstanceTest {
       return (TestNGMethodStub) this;
     };
 
-    @Override
-    public int compareTo(Object o) {
-      return 0;
-    }
-
     @SuppressWarnings("rawtypes")
     @Override
     public Class getRealClass() {


### PR DESCRIPTION
`Comparable` interface for `ITestNGMethod` is only used by `MethodInheritance` class to sort the class hierarchy. It is not implemented correctly to compare `ITestNGMethod` as mentioned in #116 and #488. The fix still does not fix the issue correctly as `x.compareTo(y) != -sign(y.compareTo(x))` when x and y come from the same class. It, therefore, makes more sense to remove `Comparable` from the interface to avoid unintentionally usage of the `Comparable` interface.
