### PR TITLE
add new feature for testng: support test parameter rendering

### DIFF
--- a/src/main/java/org/testng/annotations/IParameterRenderAnnotation.java
+++ b/src/main/java/org/testng/annotations/IParameterRenderAnnotation.java
@@ -1,0 +1,9 @@
+package org.testng.annotations;
+
+public interface IParameterRenderAnnotation extends IAnnotation {
+
+    public String getName();
+
+    public void setName(String name);
+
+}

--- a/src/main/java/org/testng/annotations/ParameterOverride.java
+++ b/src/main/java/org/testng/annotations/ParameterOverride.java
@@ -1,0 +1,12 @@
+package org.testng.annotations;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({PARAMETER})
+public @interface ParameterOverride {
+	 public String parameterRender() default "";
+}

--- a/src/main/java/org/testng/annotations/ParameterRender.java
+++ b/src/main/java/org/testng/annotations/ParameterRender.java
@@ -1,0 +1,12 @@
+package org.testng.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({METHOD})
+public @interface ParameterRender {
+	  public String name() default "";
+}

--- a/src/main/java/org/testng/collections/Lists.java
+++ b/src/main/java/org/testng/collections/Lists.java
@@ -3,6 +3,7 @@ package org.testng.collections;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 public final class Lists {
@@ -25,5 +26,18 @@ public final class Lists {
 
   public static <K> List<K> newArrayList(int size) {
     return new ArrayList<>(size);
+  }
+  
+  /**
+   * convert iterator to List
+   * 
+   * @param iterator
+   * @return
+   */
+  public static <K> List<K> newArrayList(Iterator<K> iterator) {
+      List<K> copy = new ArrayList<K>();
+      while (iterator.hasNext())
+          copy.add(iterator.next());
+      return copy;
   }
 }

--- a/src/main/java/org/testng/internal/ConstructorOrMethod.java
+++ b/src/main/java/org/testng/internal/ConstructorOrMethod.java
@@ -1,5 +1,6 @@
 package org.testng.internal;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
@@ -34,6 +35,11 @@ public class ConstructorOrMethod {
     return getMethod() != null ? getMethod().getParameterTypes() : getConstructor().getParameterTypes();
   }
 
+  public Annotation[][] getParameterAnnotations() {
+      return getMethod() != null ? 
+          getMethod().getParameterAnnotations() : getConstructor().getParameterAnnotations();
+  }
+  
   public Method getMethod() {
     return m_method;
   }

--- a/src/main/java/org/testng/internal/ParameterRenderHolder.java
+++ b/src/main/java/org/testng/internal/ParameterRenderHolder.java
@@ -1,0 +1,18 @@
+package org.testng.internal;
+
+import java.lang.reflect.Method;
+
+import org.testng.annotations.IParameterRenderAnnotation;
+
+public class ParameterRenderHolder {
+    Object                     instance;
+    Method                     method;
+    IParameterRenderAnnotation annotation;
+
+    public ParameterRenderHolder(IParameterRenderAnnotation annotation, Method method,
+                                 Object instance) {
+        this.annotation = annotation;
+        this.method = method;
+        this.instance = instance;
+    }
+}

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -530,31 +531,33 @@ public class Parameters {
                                                      ITestNGMethod testMethod, Object instance,
                                                      IAnnotationFinder annotationFinder) {
       int parameterCount = testMethod.getConstructorOrMethod().getParameterTypes().length;
-      //turn iterable parameters into ArrayList, then update the parameter by render
-      List<Object[]> parametersList = Lists.newArrayList(parameters);
+      
       Annotation[][] annotations = testMethod.getConstructorOrMethod().getParameterAnnotations();
       if (annotations == null) {
           return parameters;
       }
-
+      
+      List<Object[]> parametersList = null;
       for (int i = 0; i < parameterCount; i++) {
           for (Annotation a : annotations[i]) {
               if (a instanceof ParameterOverride) {
                   String render = ((ParameterOverride) a).parameterRender();
+                  //turn iterable parameters into ArrayList, then update the parameter by render
+                  if(parametersList==null){
+                      parametersList=Lists.newArrayList(parameters);
+                  }
                   //for now do not support define the render in another class
                   //you can only define the render in the testcase class or super
                   //maybe we can enhance here later, but that need change the @Test definition
                   ParameterRenderHolder parameterRenderHolder = findParameterRender(instance,
                       testMethod.getTestClass(), annotationFinder, render, null, null);
                   renderParameterByIndex(parametersList, parameterRenderHolder, i);
-
               }
           }
       }
 
       //turn ArrayList into iterable parameters back
-      parameters = parametersList.iterator();
-      return parameters;
+      return parametersList==null?parameters: parametersList.iterator();
   }
 
   /**

--- a/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
+++ b/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
@@ -29,11 +29,13 @@ import org.testng.annotations.IDataProviderAnnotation;
 import org.testng.annotations.IExpectedExceptionsAnnotation;
 import org.testng.annotations.IFactoryAnnotation;
 import org.testng.annotations.IObjectFactoryAnnotation;
+import org.testng.annotations.IParameterRenderAnnotation;
 import org.testng.annotations.IParametersAnnotation;
 import org.testng.annotations.ITestAnnotation;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Optional;
+import org.testng.annotations.ParameterRender;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.testng.annotations.TestInstance;
@@ -74,6 +76,7 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
     m_annotationMap.put(IBeforeMethod.class, BeforeMethod.class);
     m_annotationMap.put(IAfterMethod.class, AfterMethod.class);
     m_annotationMap.put(IListeners.class, Listeners.class);
+    m_annotationMap.put(IParameterRenderAnnotation.class, ParameterRender.class);
   }
 
   private <A extends Annotation> A findAnnotationInSuperClasses(Class<?> cls, Class<A> a) {

--- a/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -28,9 +28,11 @@ import org.testng.annotations.IDataProviderAnnotation;
 import org.testng.annotations.IExpectedExceptionsAnnotation;
 import org.testng.annotations.IFactoryAnnotation;
 import org.testng.annotations.IObjectFactoryAnnotation;
+import org.testng.annotations.IParameterRenderAnnotation;
 import org.testng.annotations.IParametersAnnotation;
 import org.testng.annotations.ITestAnnotation;
 import org.testng.annotations.Listeners;
+import org.testng.annotations.ParameterRender;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -55,6 +57,9 @@ public class JDK15TagFactory {
       }
       else if (annotationClass == IDataProviderAnnotation.class) {
         result = createDataProviderTag(a);
+      }
+      else if (annotationClass == IParameterRenderAnnotation.class) {
+        result = createPrameterRenderTag(a);
       }
       else if (annotationClass == IExpectedExceptionsAnnotation.class) {
         result = createExpectedExceptionsTag(a);
@@ -330,6 +335,13 @@ public class JDK15TagFactory {
     return result;
   }
 
+  private IAnnotation createPrameterRenderTag(Annotation a) {
+    ParameterRenderAnnotation result = new ParameterRenderAnnotation();
+    ParameterRender c = (ParameterRender) a;
+    result.setName(c.name());
+    return result;
+  }
+  
   @SuppressWarnings({"deprecation"})
   private IAnnotation createExpectedExceptionsTag(Annotation a) {
     ExpectedExceptionsAnnotation result = new ExpectedExceptionsAnnotation ();

--- a/src/main/java/org/testng/internal/annotations/ParameterRenderAnnotation.java
+++ b/src/main/java/org/testng/internal/annotations/ParameterRenderAnnotation.java
@@ -1,0 +1,23 @@
+package org.testng.internal.annotations;
+
+import org.testng.annotations.IParameterRenderAnnotation;
+
+/**
+ * An implementation of IDataProvider.
+ *
+ * Created on Dec 20, 2005
+ * @author <a href="mailto:cedric@beust.com">Cedric Beust</a>
+ */
+public class ParameterRenderAnnotation extends BaseAnnotation implements IParameterRenderAnnotation {
+    private String m_name;
+
+    @Override
+    public String getName() {
+        return m_name;
+    }
+
+    @Override
+    public void setName(String name) {
+        m_name = name;
+    }
+}

--- a/src/test/java/test/parameterrender/ArrayRenderTest.java
+++ b/src/test/java/test/parameterrender/ArrayRenderTest.java
@@ -1,0 +1,48 @@
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class ArrayRenderTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render") Object[] array) {
+        for (Object s : array) {
+            System.out.println(s);
+            Assert.assertNotEquals(s, "[GUID]");
+        }
+    }
+
+    @ParameterRender
+    public Object[] render(Object[] array) {
+        for (int i = 0; i < array.length; i++) {
+            if (array[i].equals("[GUID]")) {
+                array[i] = UUID.randomUUID().toString();
+            }
+        }
+        return array;
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { new Object[] { "abcd", "xyz" } },
+                new Object[] { new Object[] { "[GUID]", "[GUID]", "[GUID]" } }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/ArrayRenderTest.java
+++ b/src/test/java/test/parameterrender/ArrayRenderTest.java
@@ -1,48 +1,48 @@
-package test.parameterrender;
-
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.Assert;
-import org.testng.TestNG;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.ParameterOverride;
-import org.testng.annotations.ParameterRender;
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
-
-public class ArrayRenderTest {
-
-    public static void main(String[] args) {
-        TestNG testng = new TestNG();
-        List<String> suites = Lists.newArrayList();
-        suites.add("src/test/java/test/parameterrender/testng.xml");
-        testng.setTestSuites(suites);
-        testng.run();
-    }
-
-    @Test(dataProvider = "data")
-    public void doStuff2(@ParameterOverride(parameterRender = "render") Object[] array) {
-        for (Object s : array) {
-            System.out.println(s);
-            Assert.assertNotEquals(s, "[GUID]");
-        }
-    }
-
-    @ParameterRender
-    public Object[] render(Object[] array) {
-        for (int i = 0; i < array.length; i++) {
-            if (array[i].equals("[GUID]")) {
-                array[i] = UUID.randomUUID().toString();
-            }
-        }
-        return array;
-    }
-
-    @DataProvider(name = "data")
-    public Object[][] createData() {
-        return new Object[][] { new Object[] { new Object[] { "abcd", "xyz" } },
-                new Object[] { new Object[] { "[GUID]", "[GUID]", "[GUID]" } }, };
-    }
-
-}
+//package test.parameterrender;
+//
+//import java.util.List;
+//import java.util.UUID;
+//
+//import org.testng.Assert;
+//import org.testng.TestNG;
+//import org.testng.annotations.DataProvider;
+//import org.testng.annotations.ParameterOverride;
+//import org.testng.annotations.ParameterRender;
+//import org.testng.annotations.Test;
+//import org.testng.collections.Lists;
+//
+//public class ArrayRenderTest {
+//
+//    public static void main(String[] args) {
+//        TestNG testng = new TestNG();
+//        List<String> suites = Lists.newArrayList();
+//        suites.add("src/test/java/test/parameterrender/testng.xml");
+//        testng.setTestSuites(suites);
+//        testng.run();
+//    }
+//
+//    @Test(dataProvider = "data")
+//    public void doStuff2(@ParameterOverride(parameterRender = "render") Object[] array) {
+//        for (Object s : array) {
+//            System.out.println(s);
+//            Assert.assertNotEquals(s, "[GUID]");
+//        }
+//    }
+//
+//    @ParameterRender
+//    public Object[] render(Object[] array) {
+//        for (int i = 0; i < array.length; i++) {
+//            if (array[i].equals("[GUID]")) {
+//                array[i] = UUID.randomUUID().toString();
+//            }
+//        }
+//        return array;
+//    }
+//
+//    @DataProvider(name = "data")
+//    public Object[][] createData() {
+//        return new Object[][] { new Object[] { new Object[] { "abcd", "xyz" } },
+//                new Object[] { new Object[] { "[GUID]", "[GUID]", "[GUID]" } }, };
+//    }
+//
+//}

--- a/src/test/java/test/parameterrender/ArrayRenderTest.java
+++ b/src/test/java/test/parameterrender/ArrayRenderTest.java
@@ -1,48 +1,48 @@
-//package test.parameterrender;
-//
-//import java.util.List;
-//import java.util.UUID;
-//
-//import org.testng.Assert;
-//import org.testng.TestNG;
-//import org.testng.annotations.DataProvider;
-//import org.testng.annotations.ParameterOverride;
-//import org.testng.annotations.ParameterRender;
-//import org.testng.annotations.Test;
-//import org.testng.collections.Lists;
-//
-//public class ArrayRenderTest {
-//
-//    public static void main(String[] args) {
-//        TestNG testng = new TestNG();
-//        List<String> suites = Lists.newArrayList();
-//        suites.add("src/test/java/test/parameterrender/testng.xml");
-//        testng.setTestSuites(suites);
-//        testng.run();
-//    }
-//
-//    @Test(dataProvider = "data")
-//    public void doStuff2(@ParameterOverride(parameterRender = "render") Object[] array) {
-//        for (Object s : array) {
-//            System.out.println(s);
-//            Assert.assertNotEquals(s, "[GUID]");
-//        }
-//    }
-//
-//    @ParameterRender
-//    public Object[] render(Object[] array) {
-//        for (int i = 0; i < array.length; i++) {
-//            if (array[i].equals("[GUID]")) {
-//                array[i] = UUID.randomUUID().toString();
-//            }
-//        }
-//        return array;
-//    }
-//
-//    @DataProvider(name = "data")
-//    public Object[][] createData() {
-//        return new Object[][] { new Object[] { new Object[] { "abcd", "xyz" } },
-//                new Object[] { new Object[] { "[GUID]", "[GUID]", "[GUID]" } }, };
-//    }
-//
-//}
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class ArrayRenderTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render") Object[] array) {
+        for (Object s : array) {
+            System.out.println(s);
+            Assert.assertNotEquals(s, "[GUID]");
+        }
+    }
+
+    @ParameterRender
+    public Object[] render(Object[] array) {
+        for (int i = 0; i < array.length; i++) {
+            if (array[i].equals("[GUID]")) {
+                array[i] = UUID.randomUUID().toString();
+            }
+        }
+        return array;
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { new Object[] { "abcd", "xyz" } },
+                new Object[] { new Object[] { "[GUID]", "[GUID]", "[GUID]" } }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/Convert2GUIDTest.java
+++ b/src/test/java/test/parameterrender/Convert2GUIDTest.java
@@ -1,49 +1,49 @@
-package test.parameterrender;
-
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.Assert;
-import org.testng.TestNG;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.ParameterOverride;
-import org.testng.annotations.ParameterRender;
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
-
-/**
- * in this test, test method parameter will be updated by the ParameterRender
- * 
- * @author sayid
- */
-public class Convert2GUIDTest {
-
-    public static void main(String[] args) {
-        TestNG testng = new TestNG();
-        List<String> suites = Lists.newArrayList();
-        suites.add("src/test/java/test/parameterrender/testng.xml");
-        testng.setTestSuites(suites);
-        testng.run();
-    }
-
-    @Test(dataProvider = "data")
-    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
-        System.out.println(s);
-        Assert.assertNotEquals(s, "[GUID]");
-    }
-
-    @ParameterRender(name = "convert2Guid")
-    public String convert2Guid(String s) {
-        if (s.equals("[GUID]")) {
-            return UUID.randomUUID().toString();
-        } else {
-            return s;
-        }
-    }
-
-    @DataProvider(name = "data")
-    public Object[][] createData() {
-        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
-    }
-
-}
+//package test.parameterrender;
+//
+//import java.util.List;
+//import java.util.UUID;
+//
+//import org.testng.Assert;
+//import org.testng.TestNG;
+//import org.testng.annotations.DataProvider;
+//import org.testng.annotations.ParameterOverride;
+//import org.testng.annotations.ParameterRender;
+//import org.testng.annotations.Test;
+//import org.testng.collections.Lists;
+//
+///**
+// * in this test, test method parameter will be updated by the ParameterRender
+// * 
+// * @author sayid
+// */
+//public class Convert2GUIDTest {
+//
+//    public static void main(String[] args) {
+//        TestNG testng = new TestNG();
+//        List<String> suites = Lists.newArrayList();
+//        suites.add("src/test/java/test/parameterrender/testng.xml");
+//        testng.setTestSuites(suites);
+//        testng.run();
+//    }
+//
+//    @Test(dataProvider = "data")
+//    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
+//        System.out.println(s);
+//        Assert.assertNotEquals(s, "[GUID]");
+//    }
+//
+//    @ParameterRender(name = "convert2Guid")
+//    public String convert2Guid(String s) {
+//        if (s.equals("[GUID]")) {
+//            return UUID.randomUUID().toString();
+//        } else {
+//            return s;
+//        }
+//    }
+//
+//    @DataProvider(name = "data")
+//    public Object[][] createData() {
+//        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+//    }
+//
+//}

--- a/src/test/java/test/parameterrender/Convert2GUIDTest.java
+++ b/src/test/java/test/parameterrender/Convert2GUIDTest.java
@@ -1,0 +1,49 @@
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+/**
+ * in this test, test method parameter will be updated by the ParameterRender
+ * 
+ * @author sayid
+ */
+public class Convert2GUIDTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
+        System.out.println(s);
+        Assert.assertNotEquals(s, "[GUID]");
+    }
+
+    @ParameterRender(name = "convert2Guid")
+    public String convert2Guid(String s) {
+        if (s.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return s;
+        }
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/Convert2GUIDTest.java
+++ b/src/test/java/test/parameterrender/Convert2GUIDTest.java
@@ -1,49 +1,49 @@
-//package test.parameterrender;
-//
-//import java.util.List;
-//import java.util.UUID;
-//
-//import org.testng.Assert;
-//import org.testng.TestNG;
-//import org.testng.annotations.DataProvider;
-//import org.testng.annotations.ParameterOverride;
-//import org.testng.annotations.ParameterRender;
-//import org.testng.annotations.Test;
-//import org.testng.collections.Lists;
-//
-///**
-// * in this test, test method parameter will be updated by the ParameterRender
-// * 
-// * @author sayid
-// */
-//public class Convert2GUIDTest {
-//
-//    public static void main(String[] args) {
-//        TestNG testng = new TestNG();
-//        List<String> suites = Lists.newArrayList();
-//        suites.add("src/test/java/test/parameterrender/testng.xml");
-//        testng.setTestSuites(suites);
-//        testng.run();
-//    }
-//
-//    @Test(dataProvider = "data")
-//    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
-//        System.out.println(s);
-//        Assert.assertNotEquals(s, "[GUID]");
-//    }
-//
-//    @ParameterRender(name = "convert2Guid")
-//    public String convert2Guid(String s) {
-//        if (s.equals("[GUID]")) {
-//            return UUID.randomUUID().toString();
-//        } else {
-//            return s;
-//        }
-//    }
-//
-//    @DataProvider(name = "data")
-//    public Object[][] createData() {
-//        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
-//    }
-//
-//}
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+/**
+ * in this test, test method parameter will be updated by the ParameterRender
+ * 
+ * @author sayid
+ */
+public class Convert2GUIDTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
+        System.out.println(s);
+        Assert.assertNotEquals(s, "[GUID]");
+    }
+
+    @ParameterRender(name = "convert2Guid")
+    public String convert2Guid(String s) {
+        if (s.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return s;
+        }
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/DefaultRenderNameTest.java
+++ b/src/test/java/test/parameterrender/DefaultRenderNameTest.java
@@ -1,44 +1,44 @@
-package test.parameterrender;
-
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.Assert;
-import org.testng.TestNG;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.ParameterOverride;
-import org.testng.annotations.ParameterRender;
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
-
-public class DefaultRenderNameTest {
-
-    public static void main(String[] args) {
-        TestNG testng = new TestNG();
-        List<String> suites = Lists.newArrayList();
-        suites.add("src/test/java/test/parameterrender/testng.xml");
-        testng.setTestSuites(suites);
-        testng.run();
-    }
-
-    @Test(dataProvider = "data")
-    public void doStuff2(@ParameterOverride(parameterRender = "render") String s) {
-        System.out.println(s);
-        Assert.assertNotEquals(s, "[GUID]");
-    }
-
-    @ParameterRender
-    public String render(String s) {
-        if (s.equals("[GUID]")) {
-            return UUID.randomUUID().toString();
-        } else {
-            return s;
-        }
-    }
-
-    @DataProvider(name = "data")
-    public Object[][] createData() {
-        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
-    }
-
-}
+//package test.parameterrender;
+//
+//import java.util.List;
+//import java.util.UUID;
+//
+//import org.testng.Assert;
+//import org.testng.TestNG;
+//import org.testng.annotations.DataProvider;
+//import org.testng.annotations.ParameterOverride;
+//import org.testng.annotations.ParameterRender;
+//import org.testng.annotations.Test;
+//import org.testng.collections.Lists;
+//
+//public class DefaultRenderNameTest {
+//
+//    public static void main(String[] args) {
+//        TestNG testng = new TestNG();
+//        List<String> suites = Lists.newArrayList();
+//        suites.add("src/test/java/test/parameterrender/testng.xml");
+//        testng.setTestSuites(suites);
+//        testng.run();
+//    }
+//
+//    @Test(dataProvider = "data")
+//    public void doStuff2(@ParameterOverride(parameterRender = "render") String s) {
+//        System.out.println(s);
+//        Assert.assertNotEquals(s, "[GUID]");
+//    }
+//
+//    @ParameterRender
+//    public String render(String s) {
+//        if (s.equals("[GUID]")) {
+//            return UUID.randomUUID().toString();
+//        } else {
+//            return s;
+//        }
+//    }
+//
+//    @DataProvider(name = "data")
+//    public Object[][] createData() {
+//        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+//    }
+//
+//}

--- a/src/test/java/test/parameterrender/DefaultRenderNameTest.java
+++ b/src/test/java/test/parameterrender/DefaultRenderNameTest.java
@@ -1,44 +1,44 @@
-//package test.parameterrender;
-//
-//import java.util.List;
-//import java.util.UUID;
-//
-//import org.testng.Assert;
-//import org.testng.TestNG;
-//import org.testng.annotations.DataProvider;
-//import org.testng.annotations.ParameterOverride;
-//import org.testng.annotations.ParameterRender;
-//import org.testng.annotations.Test;
-//import org.testng.collections.Lists;
-//
-//public class DefaultRenderNameTest {
-//
-//    public static void main(String[] args) {
-//        TestNG testng = new TestNG();
-//        List<String> suites = Lists.newArrayList();
-//        suites.add("src/test/java/test/parameterrender/testng.xml");
-//        testng.setTestSuites(suites);
-//        testng.run();
-//    }
-//
-//    @Test(dataProvider = "data")
-//    public void doStuff2(@ParameterOverride(parameterRender = "render") String s) {
-//        System.out.println(s);
-//        Assert.assertNotEquals(s, "[GUID]");
-//    }
-//
-//    @ParameterRender
-//    public String render(String s) {
-//        if (s.equals("[GUID]")) {
-//            return UUID.randomUUID().toString();
-//        } else {
-//            return s;
-//        }
-//    }
-//
-//    @DataProvider(name = "data")
-//    public Object[][] createData() {
-//        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
-//    }
-//
-//}
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class DefaultRenderNameTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render") String s) {
+        System.out.println(s);
+        Assert.assertNotEquals(s, "[GUID]");
+    }
+
+    @ParameterRender
+    public String render(String s) {
+        if (s.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return s;
+        }
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/DefaultRenderNameTest.java
+++ b/src/test/java/test/parameterrender/DefaultRenderNameTest.java
@@ -1,0 +1,44 @@
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class DefaultRenderNameTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render") String s) {
+        System.out.println(s);
+        Assert.assertNotEquals(s, "[GUID]");
+    }
+
+    @ParameterRender
+    public String render(String s) {
+        if (s.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return s;
+        }
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] { new Object[] { "abcd" }, new Object[] { "[GUID]" }, };
+    }
+
+}

--- a/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
+++ b/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
@@ -1,69 +1,69 @@
-package test.parameterrender;
-
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.Assert;
-import org.testng.TestNG;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.ParameterOverride;
-import org.testng.annotations.ParameterRender;
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
-
-public class MultipleParameterRenderTest {
-
-    public static void main(String[] args) {
-        TestNG testng = new TestNG();
-        List<String> suites = Lists.newArrayList();
-        suites.add("src/test/java/test/parameterrender/testng.xml");
-        testng.setTestSuites(suites);
-        testng.run();
-    }
-
-    @Test(dataProvider = "data")
-    public void doStuff2(@ParameterOverride(parameterRender = "render1") int id,
-                         @ParameterOverride(parameterRender = "render2") String s,
-                         @ParameterOverride(parameterRender = "render3") Object[] array) {
-        System.out.println(id + "," + s);
-        Assert.assertNotEquals(s, "[GUID]");
-
-        System.out.println("printing array...");
-        for (Object o : array) {
-            System.out.println(o.toString());
-            Assert.assertNotEquals(o.toString(), "[GUID]");
-        }
-    }
-
-    @ParameterRender(name = "render1")
-    public int render1(int i) {
-        return i * 10;
-    }
-
-    @ParameterRender(name = "render2")
-    public String render2(String o) {
-        if (o.equals("[GUID]")) {
-            return UUID.randomUUID().toString();
-        } else {
-            return o;
-        }
-    }
-
-    @ParameterRender(name = "render3")
-    public Object[] render3(Object[] array) {
-        for (int i = 0; i < array.length; i++) {
-            if (array[i].equals("[GUID]")) {
-                array[i] = UUID.randomUUID().toString();
-            }
-        }
-        return array;
-    }
-
-    @DataProvider(name = "data")
-    public Object[][] createData() {
-        return new Object[][] {
-                new Object[] { 1, "abcd", new Object[] { "[www]", "[GUID]", "iii" } },
-                new Object[] { 2, "[GUID]", new Object[] { "ttt" } } };
-    }
-
-}
+//package test.parameterrender;
+//
+//import java.util.List;
+//import java.util.UUID;
+//
+//import org.testng.Assert;
+//import org.testng.TestNG;
+//import org.testng.annotations.DataProvider;
+//import org.testng.annotations.ParameterOverride;
+//import org.testng.annotations.ParameterRender;
+//import org.testng.annotations.Test;
+//import org.testng.collections.Lists;
+//
+//public class MultipleParameterRenderTest {
+//
+//    public static void main(String[] args) {
+//        TestNG testng = new TestNG();
+//        List<String> suites = Lists.newArrayList();
+//        suites.add("src/test/java/test/parameterrender/testng.xml");
+//        testng.setTestSuites(suites);
+//        testng.run();
+//    }
+//
+//    @Test(dataProvider = "data")
+//    public void doStuff2(@ParameterOverride(parameterRender = "render1") int id,
+//                         @ParameterOverride(parameterRender = "render2") String s,
+//                         @ParameterOverride(parameterRender = "render3") Object[] array) {
+//        System.out.println(id + "," + s);
+//        Assert.assertNotEquals(s, "[GUID]");
+//
+//        System.out.println("printing array...");
+//        for (Object o : array) {
+//            System.out.println(o.toString());
+//            Assert.assertNotEquals(o.toString(), "[GUID]");
+//        }
+//    }
+//
+//    @ParameterRender(name = "render1")
+//    public int render1(int i) {
+//        return i * 10;
+//    }
+//
+//    @ParameterRender(name = "render2")
+//    public String render2(String o) {
+//        if (o.equals("[GUID]")) {
+//            return UUID.randomUUID().toString();
+//        } else {
+//            return o;
+//        }
+//    }
+//
+//    @ParameterRender(name = "render3")
+//    public Object[] render3(Object[] array) {
+//        for (int i = 0; i < array.length; i++) {
+//            if (array[i].equals("[GUID]")) {
+//                array[i] = UUID.randomUUID().toString();
+//            }
+//        }
+//        return array;
+//    }
+//
+//    @DataProvider(name = "data")
+//    public Object[][] createData() {
+//        return new Object[][] {
+//                new Object[] { 1, "abcd", new Object[] { "[www]", "[GUID]", "iii" } },
+//                new Object[] { 2, "[GUID]", new Object[] { "ttt" } } };
+//    }
+//
+//}

--- a/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
+++ b/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
@@ -1,0 +1,69 @@
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class MultipleParameterRenderTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render1") int id,
+                         @ParameterOverride(parameterRender = "render2") String s,
+                         @ParameterOverride(parameterRender = "render3") Object[] array) {
+        System.out.println(id + "," + s);
+        Assert.assertNotEquals(s, "[GUID]");
+
+        System.out.println("printing array...");
+        for (Object o : array) {
+            System.out.println(o.toString());
+            Assert.assertNotEquals(o.toString(), "[GUID]");
+        }
+    }
+
+    @ParameterRender(name = "render1")
+    public int render1(int i) {
+        return i * 10;
+    }
+
+    @ParameterRender(name = "render2")
+    public String render2(String o) {
+        if (o.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return o;
+        }
+    }
+
+    @ParameterRender(name = "render3")
+    public Object[] render3(Object[] array) {
+        for (int i = 0; i < array.length; i++) {
+            if (array[i].equals("[GUID]")) {
+                array[i] = UUID.randomUUID().toString();
+            }
+        }
+        return array;
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] {
+                new Object[] { 1, "abcd", new Object[] { "[www]", "[GUID]", "iii" } },
+                new Object[] { 2, "[GUID]", new Object[] { "ttt" } } };
+    }
+
+}

--- a/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
+++ b/src/test/java/test/parameterrender/MultipleParameterRenderTest.java
@@ -1,69 +1,69 @@
-//package test.parameterrender;
-//
-//import java.util.List;
-//import java.util.UUID;
-//
-//import org.testng.Assert;
-//import org.testng.TestNG;
-//import org.testng.annotations.DataProvider;
-//import org.testng.annotations.ParameterOverride;
-//import org.testng.annotations.ParameterRender;
-//import org.testng.annotations.Test;
-//import org.testng.collections.Lists;
-//
-//public class MultipleParameterRenderTest {
-//
-//    public static void main(String[] args) {
-//        TestNG testng = new TestNG();
-//        List<String> suites = Lists.newArrayList();
-//        suites.add("src/test/java/test/parameterrender/testng.xml");
-//        testng.setTestSuites(suites);
-//        testng.run();
-//    }
-//
-//    @Test(dataProvider = "data")
-//    public void doStuff2(@ParameterOverride(parameterRender = "render1") int id,
-//                         @ParameterOverride(parameterRender = "render2") String s,
-//                         @ParameterOverride(parameterRender = "render3") Object[] array) {
-//        System.out.println(id + "," + s);
-//        Assert.assertNotEquals(s, "[GUID]");
-//
-//        System.out.println("printing array...");
-//        for (Object o : array) {
-//            System.out.println(o.toString());
-//            Assert.assertNotEquals(o.toString(), "[GUID]");
-//        }
-//    }
-//
-//    @ParameterRender(name = "render1")
-//    public int render1(int i) {
-//        return i * 10;
-//    }
-//
-//    @ParameterRender(name = "render2")
-//    public String render2(String o) {
-//        if (o.equals("[GUID]")) {
-//            return UUID.randomUUID().toString();
-//        } else {
-//            return o;
-//        }
-//    }
-//
-//    @ParameterRender(name = "render3")
-//    public Object[] render3(Object[] array) {
-//        for (int i = 0; i < array.length; i++) {
-//            if (array[i].equals("[GUID]")) {
-//                array[i] = UUID.randomUUID().toString();
-//            }
-//        }
-//        return array;
-//    }
-//
-//    @DataProvider(name = "data")
-//    public Object[][] createData() {
-//        return new Object[][] {
-//                new Object[] { 1, "abcd", new Object[] { "[www]", "[GUID]", "iii" } },
-//                new Object[] { 2, "[GUID]", new Object[] { "ttt" } } };
-//    }
-//
-//}
+package test.parameterrender;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ParameterOverride;
+import org.testng.annotations.ParameterRender;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class MultipleParameterRenderTest {
+
+    public static void main(String[] args) {
+        TestNG testng = new TestNG();
+        List<String> suites = Lists.newArrayList();
+        suites.add("src/test/java/test/parameterrender/testng.xml");
+        testng.setTestSuites(suites);
+        testng.run();
+    }
+
+    @Test(dataProvider = "data")
+    public void doStuff2(@ParameterOverride(parameterRender = "render1") int id,
+                         @ParameterOverride(parameterRender = "render2") String s,
+                         @ParameterOverride(parameterRender = "render3") Object[] array) {
+        System.out.println(id + "," + s);
+        Assert.assertNotEquals(s, "[GUID]");
+
+        System.out.println("printing array...");
+        for (Object o : array) {
+            System.out.println(o.toString());
+            Assert.assertNotEquals(o.toString(), "[GUID]");
+        }
+    }
+
+    @ParameterRender(name = "render1")
+    public int render1(int i) {
+        return i * 10;
+    }
+
+    @ParameterRender(name = "render2")
+    public String render2(String o) {
+        if (o.equals("[GUID]")) {
+            return UUID.randomUUID().toString();
+        } else {
+            return o;
+        }
+    }
+
+    @ParameterRender(name = "render3")
+    public Object[] render3(Object[] array) {
+        for (int i = 0; i < array.length; i++) {
+            if (array[i].equals("[GUID]")) {
+                array[i] = UUID.randomUUID().toString();
+            }
+        }
+        return array;
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] createData() {
+        return new Object[][] {
+                new Object[] { 1, "abcd", new Object[] { "[www]", "[GUID]", "iii" } },
+                new Object[] { 2, "[GUID]", new Object[] { "ttt" } } };
+    }
+
+}

--- a/src/test/java/test/parameterrender/testng.xml
+++ b/src/test/java/test/parameterrender/testng.xml
@@ -1,0 +1,32 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Configuration failures" verbose="2">
+	<!--
+  <test name="Suite Configuration">
+		<classes>
+			<class name="org.testng.internal.conflistener.FailingBeforeSuite" />
+			<class name="org.testng.internal.conflistener.FailingAfterSuite" />
+		</classes>
+  </test>
+	-->
+<!-- 	<test name="Test Configuration">
+		<classes>
+			<class name="org.testng.internal.conflistener.FailingBeforeTest" />
+			<class name="org.testng.internal.conflistener.FailingAfterTest" />
+		</classes>
+  </test>
+	<test name="Class Configuration">
+		<classes>
+			<class name="org.testng.internal.conflistener.FailingBeforeClass" />
+      <class name="org.testng.internal.conflistener.FailingAfterClass" />
+    </classes>
+  </test> -->
+
+	<test name="Convert2GUIDTest">
+		<classes>
+			<class name="test.parameterrender.MultipleParameterRenderTest" />
+			<class name="test.parameterrender.DefaultRenderNameTest" />
+			<class name="test.parameterrender.Convert2GUIDTest" />
+			<class name="test.parameterrender.ArrayRenderTest" />
+		</classes>
+  </test>
+</suite>


### PR DESCRIPTION
what is parameter render?
you test use DataProvider to generate a group of Strings, and you want to define the Strings input as some thing like macro, then you can update the macro with dynamic values before calling the test method.
for example: when the input string is "[GUID]", you want to relace it with real GUID value.

now use annotations @ParameterRender and @ParameterOverride you can get this.

here is a simple code sample:
    @Test(dataProvider = "data")
    public void doStuff(@ParameterOverride(parameterRender = "convert2Guid") String s) {
        System.out.println(s);
        Assert.assertNotEquals(s, "[GUID]");
    }

    @ParameterRender(name = "convert2Guid")
    public String convert2Guid(String s) {
        if (s.equals("[GUID]")) {
            return UUID.randomUUID().toString();
        } else {
            return s;
        }
    }

    @DataProvider(name = "data")
    public Object[][] createData() {
        return new Object[][] { new Object[] { "abcd" }, new Object[{ "[GUID]" }, };
    }


so you can see, i add two annotations, use @ParameterOverride(parameterRender = "xxx") to define the render for parameter, use     @ParameterRender(name = "xxx")  to response ParameterOverride.

unit tests:
add 4 tests: 
Convert2GUIDTest.java
DefaultRenderNameTest.java
ArrayRenderTest.java
MultipleParameterRenderTest.java

NOTICE: the 4 tests will fail under old version testng eclipse plugin because the old does not include the new annotation i added.
 