### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/testng/ConversionUtils.java
+++ b/src/main/java/org/testng/ConversionUtils.java
@@ -11,7 +11,11 @@ import java.util.List;
  * @author Cedric Beust <cedric@beust.com>
  *
  */
-public class ConversionUtils {
+public final class ConversionUtils {
+  private ConversionUtils() {
+    throw new AssertionError("Must not instantiate this class");
+  }
+
   /**
    * Turns the output of a JUnit 4 @Parameters style data provider into
    * one that is suitable for TestNG's @DataProvider.

--- a/src/main/java/org/testng/Reporter.java
+++ b/src/main/java/org/testng/Reporter.java
@@ -27,7 +27,7 @@ import org.testng.util.Strings;
  * Created on Nov 2, 2005
  * @author cbeust
  */
-public class Reporter {
+public final class Reporter {
   // when tests are run in parallel, each thread may be working with different
   // 'current test result'. Also, this value should be inherited if the test code
   // spawns its own thread.
@@ -45,6 +45,10 @@ public class Reporter {
   //This variable is responsible for persisting all output that is yet to be associated with any
   //valid TestResult objects.
   private static ThreadLocal<List<String>> m_orphanedOutput = new InheritableThreadLocal<>();
+
+  private Reporter() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static void setCurrentTestResult(ITestResult m) {
     m_currentTestResult.set(m);

--- a/src/main/java/org/testng/TestNGUtils.java
+++ b/src/main/java/org/testng/TestNGUtils.java
@@ -4,7 +4,11 @@ import org.testng.internal.ClonedMethod;
 
 import java.lang.reflect.Method;
 
-public class TestNGUtils {
+public final class TestNGUtils {
+
+  private TestNGUtils() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /**
    * Create an ITestNGMethod for @code{method} based on @code{existingMethod}, which needs

--- a/src/main/java/org/testng/collections/Maps.java
+++ b/src/main/java/org/testng/collections/Maps.java
@@ -6,7 +6,11 @@ import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class Maps {
+public final class Maps {
+
+  private Maps() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static <K, V> Map<K,V> newHashMap() {
     return new HashMap<>();

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -25,13 +25,17 @@ import org.testng.internal.collections.Pair;
  * @author nullin <nalin.makar * gmail.com>
  *
  */
-public class MethodGroupsHelper {
+public final class MethodGroupsHelper {
 
   private static final Map<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<>();
   private static final Map<Pair<String, String>, Boolean> MATCH_CACHE =
           new ConcurrentHashMap<>();
 
-    /**
+  private MethodGroupsHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
+
+  /**
    * Collect all the methods that belong to the included groups and exclude all
    * the methods that belong to an excluded group.
    */

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -27,12 +27,16 @@ import org.testng.internal.collections.Pair;
  * @author <a href="mailto:cedric@beust.com">Cedric Beust</a>
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
-public class MethodHelper {
+public final class MethodHelper {
   private static final Map<ITestNGMethod[], Graph<ITestNGMethod>> GRAPH_CACHE =
           new ConcurrentHashMap<>();
   private static final Map<Method, String> CANONICAL_NAME_CACHE = new ConcurrentHashMap<>();
   private static final Map<Pair<String, String>, Boolean> MATCH_CACHE =
           new ConcurrentHashMap<>();
+
+  private MethodHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /**
    * Collects and orders test or configuration methods

--- a/src/main/java/org/testng/internal/MethodInheritance.java
+++ b/src/main/java/org/testng/internal/MethodInheritance.java
@@ -8,7 +8,11 @@ import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 
-public class MethodInheritance {
+public final class MethodInheritance {
+  private MethodInheritance() {
+    throw new AssertionError("Must not instantiate this class");
+  }
+
   /**
    * Look in map for a class that is a superclass of methodClass
    */

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -35,7 +35,11 @@ import java.util.List;
  * @author nullin <nalin.makar * gmail.com>
  *
  */
-public class MethodInvocationHelper {
+public final class MethodInvocationHelper {
+
+  private MethodInvocationHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   protected static Object invokeMethod(Method thisMethod, Object instance, Object[] parameters)
       throws InvocationTargetException, IllegalAccessException {

--- a/src/main/java/org/testng/internal/PackageUtils.java
+++ b/src/main/java/org/testng/internal/PackageUtils.java
@@ -26,11 +26,15 @@ import org.testng.collections.Lists;
  * Created on Feb 24, 2006
  * @author <a href="mailto:cedric@beust.com">Cedric Beust</a>
  */
-public class PackageUtils {
+public final class PackageUtils {
   private static String[] s_testClassPaths;
 
   /** The additional class loaders to find classes in. */
   private static final List<ClassLoader> m_classLoaders = new Vector<>();
+
+  private PackageUtils() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /** Add a class loader to the searchable loaders. */
   public static void addClassLoader(final ClassLoader loader) {

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -38,8 +38,12 @@ import org.testng.xml.XmlTest;
  *
  * @author <a href="mailto:cedric@beust.com">Cedric Beust</a>
  */
-public class Parameters {
+public final class Parameters {
   public static final String NULL_VALUE= "null";
+
+  private Parameters() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /**
    * Creates the parameters needed for constructing a test class instance.

--- a/src/main/java/org/testng/internal/PropertyUtils.java
+++ b/src/main/java/org/testng/internal/PropertyUtils.java
@@ -14,9 +14,13 @@ import java.lang.reflect.Method;
  *
  * @author Cosmin Marginean, Apr 12, 2007
  */
-public class PropertyUtils {
+public final class PropertyUtils {
 
   private static final Logger LOGGER = Logger.getLogger(PropertyUtils.class);
+
+  private PropertyUtils() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static void setProperty(Object instance, String name, String value) {
     if (instance == null) {

--- a/src/main/java/org/testng/internal/Yaml.java
+++ b/src/main/java/org/testng/internal/Yaml.java
@@ -23,7 +23,11 @@ import java.util.Map;
  *
  * @author Cedric Beust <cedric@beust.com>
  */
-public class Yaml {
+public final class Yaml {
+
+  private Yaml() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static XmlSuite parse(String filePath, InputStream is)
       throws FileNotFoundException {

--- a/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -26,7 +26,11 @@ import org.testng.xml.XmlTest;
  * Created on Dec 20, 2005
  * @author cbeust
  */
-public class AnnotationHelper {
+public final class AnnotationHelper {
+
+  private AnnotationHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static ITestAnnotation findTest(IAnnotationFinder finder, Class<?> cls) {
     return finder.findAnnotation(cls, ITestAnnotation.class);

--- a/src/main/java/org/testng/internal/annotations/Converter.java
+++ b/src/main/java/org/testng/internal/annotations/Converter.java
@@ -13,7 +13,11 @@ import java.util.StringTokenizer;
  * Created on Dec 20, 2005
  * @author cbeust
  */
-public class Converter {
+public final class Converter {
+
+  private Converter() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static boolean  getBoolean(String tagValue, boolean def) {
     boolean result = def;

--- a/src/main/java/org/testng/internal/thread/ThreadUtil.java
+++ b/src/main/java/org/testng/internal/thread/ThreadUtil.java
@@ -17,8 +17,12 @@ import java.util.concurrent.TimeUnit;
  *
  * @author <a href="mailto:the_mindstorm@evolva.ro>Alex Popescu</a>
  */
-public class ThreadUtil {
+public final class ThreadUtil {
   private static final String THREAD_NAME = "TestNG";
+
+  private ThreadUtil() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /**
    * @return true if the current thread was created by TestNG.

--- a/src/main/java/org/testng/junit/JUnitTestFinder.java
+++ b/src/main/java/org/testng/junit/JUnitTestFinder.java
@@ -28,6 +28,10 @@ public final class JUnitTestFinder {
         }
     }
 
+    private JUnitTestFinder() {
+        throw new AssertionError("Must not instantiate this class");
+    }
+
     public static boolean isJUnitTest(Class c) {
         if (!haveJUnit()) {
             return false;

--- a/src/main/java/org/testng/remote/strprotocol/MessageHelper.java
+++ b/src/main/java/org/testng/remote/strprotocol/MessageHelper.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  *
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
-public class MessageHelper {
+public final class MessageHelper {
   public static final char DELIMITER = '\u0001';
   public static final char PARAM_DELIMITER = '\u0004';
   private static final char LINE_SEP_DELIMITER_1 = '\u0002';
@@ -38,6 +38,10 @@ public class MessageHelper {
 
   public static final String STOP_MSG = ">STOP";
   public static final String ACK_MSG = ">ACK";
+
+  private MessageHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static int getMessageType(final String message) {
     int idx = message.indexOf(DELIMITER);

--- a/src/main/java/org/testng/reporters/Files.java
+++ b/src/main/java/org/testng/reporters/Files.java
@@ -15,7 +15,11 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 
-public class Files {
+public final class Files {
+
+  private Files() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static String readFile(File f) throws IOException {
     try (InputStream is = new FileInputStream(f)) {

--- a/src/main/java/org/testng/reporters/HtmlHelper.java
+++ b/src/main/java/org/testng/reporters/HtmlHelper.java
@@ -5,9 +5,13 @@ import org.testng.internal.Utils;
 import java.io.File;
 import java.io.IOException;
 
-public class HtmlHelper {
+public final class HtmlHelper {
   private static final String CSS_FILE_NAME = "testng.css";
   private static final String MY_CSS_FILE_NAME = "my-testng.css";
+
+  private HtmlHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   static public String getCssString() {
     return getCssString("..");

--- a/src/main/java/org/testng/reporters/util/StackTraceTools.java
+++ b/src/main/java/org/testng/reporters/util/StackTraceTools.java
@@ -9,7 +9,10 @@ import org.testng.ITestNGMethod;
  * @since 5.3
  * @version $Revision: 173 $
  */
-public class StackTraceTools {
+public final class StackTraceTools {
+  private StackTraceTools() {
+    throw new AssertionError("Must not instantiate this class");
+  }
   // ~ Methods --------------------------------------------------------------
 
   /** Finds topmost position of the test method in the stack, or top of stack if <code>method</code> is not in it. */

--- a/src/main/java/org/testng/xml/SuiteGenerator.java
+++ b/src/main/java/org/testng/xml/SuiteGenerator.java
@@ -12,8 +12,12 @@ import java.util.Map;
  *         Date: Jul 25, 2005
  *         Time: 1:12:18 PM
  */
-public class SuiteGenerator {
+public final class SuiteGenerator {
   private static final Collection<String> EMPTY_CLASS_LIST= Collections.emptyList();
+
+  private SuiteGenerator() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static LaunchSuite createProxiedXmlSuite(final File xmlSuitePath) {
     return new LaunchSuite.ExistingSuite(xmlSuitePath);

--- a/src/main/java/org/testng/xml/XmlUtils.java
+++ b/src/main/java/org/testng/xml/XmlUtils.java
@@ -6,7 +6,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
-public class XmlUtils {
+public final class XmlUtils {
+
+  private XmlUtils() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   /**
    * Don't add this property if it's equal to its default value.

--- a/src/main/java/org/testng/xml/dom/Reflect.java
+++ b/src/main/java/org/testng/xml/dom/Reflect.java
@@ -8,7 +8,11 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-public class Reflect {
+public final class Reflect {
+  private Reflect() {
+    throw new AssertionError("Must not instantiate this class");
+  }
+
   public static List<Pair<Method, Wrapper>> findMethodsWithAnnotation(
       Class<?> c, Class<? extends Annotation> ac, Object bean) {
     List<Pair<Method, Wrapper>> result = Lists.newArrayList();

--- a/src/test/java/test/TestHelper.java
+++ b/src/test/java/test/TestHelper.java
@@ -11,7 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-public class TestHelper {
+public final class TestHelper {
+
+  private TestHelper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static XmlSuite createSuite(String cls, String suiteName) {
     return createSuite(cls, suiteName, "TmpTest");

--- a/src/test/java/test/thread/Helper.java
+++ b/src/test/java/test/thread/Helper.java
@@ -3,8 +3,12 @@ package test.thread;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Helper {
+public final class Helper {
   private static Map<String, Map<Long, Long>> m_maps = new HashMap<>();
+
+  private Helper() {
+    throw new AssertionError("Must not instantiate this class");
+  }
 
   public static Map<Long, Long> getMap(String className) {
     synchronized(m_maps) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Kirill Vlasov
