### PR TITLE
Fix for issue #960

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Fixed: GITHUB-793: Test suite with tests using dependency and priority has wrong
 Fixed: GITHUB-922: ITestResult doesn't contain name if a class has @Test (@dr29bart & Julien Herr)
 Fixed: GITHUB-419: parallel mode was ignored with command line (@khospodarysko & Julien Herr)
 New: GITHUB-932: Deprecate true/false parallel values. none is the new default value. (Julien Herr)
+Fixed: GITHUB-960: testng-failed.xml gets generated even when there are no failures. (Krishnan Mahadevan)
 ﻿
 6.9.10:
 2015/12/15

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -59,11 +59,16 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
     }
 
     Map<String, ISuiteResult> results = suite.getResults();
+    boolean hasFailures = false;
 
     synchronized(results) {
       for(Map.Entry<String, ISuiteResult> entry : results.entrySet()) {
         ISuiteResult suiteResult = entry.getValue();
         ITestContext testContext = suiteResult.getTestContext();
+        if (! testContext.getFailedTests().getAllResults().isEmpty() || (! testContext.getSkippedTests()
+            .getAllResults().isEmpty())) {
+          hasFailures = true;
+        }
 
         generateXmlTest(suite,
                         xmlTests.get(testContext.getName()),
@@ -73,7 +78,7 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
       }
     }
 
-    if(null != failedSuite.getTests() && failedSuite.getTests().size() > 0) {
+    if(hasFailures && null != failedSuite.getTests() && failedSuite.getTests().size() > 0) {
       Utils.writeUtf8File(outputDir, TESTNG_FAILED_XML, failedSuite.toXml());
       Utils.writeUtf8File(suite.getOutputDirectory(), TESTNG_FAILED_XML, failedSuite.toXml());
     }

--- a/src/test/java/test/failedreporter/FailedReporterLocalTestClass.java
+++ b/src/test/java/test/failedreporter/FailedReporterLocalTestClass.java
@@ -1,0 +1,27 @@
+package test.failedreporter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * A simple test class that is used by {@link FailedReporterScenariosTest} class to test out the presence/absence
+ * of testng-failed.xml file when there are failures/no failures scenarios.
+ */
+public class FailedReporterLocalTestClass {
+
+    public static class WithFailure {
+        @Test
+        public void testMethod() {
+            Assert.assertTrue(false);
+        }
+
+    }
+
+    public static class WithoutFailure {
+        @Test
+        public void testMethod() {
+            Assert.assertTrue(true);
+        }
+
+    }
+}

--- a/src/test/java/test/failedreporter/FailedReporterScenariosTest.java
+++ b/src/test/java/test/failedreporter/FailedReporterScenariosTest.java
@@ -1,0 +1,81 @@
+package test.failedreporter;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.reporters.FailedReporter;
+import test.BaseTest;
+
+import java.io.File;
+import java.util.UUID;
+
+public class FailedReporterScenariosTest extends BaseTest {
+    private File tempDir = new File(System.getProperty("java.io.tmpdir"));
+
+    @Test
+    public void testFileCreationSkipWhenNoFailuresExist() {
+        File fileLocation = runTests(false);
+        try {
+            Assert.assertFalse(getLocation(fileLocation).exists());
+        } finally {
+            if (fileLocation.exists()) {
+                deleteRecursive(fileLocation);
+            }
+        }
+    }
+
+    @Test
+    public void testFileCreationWhenFailuresExist() {
+        File fileLocation = runTests(true);
+        try {
+            Assert.assertTrue(getLocation(fileLocation).exists());
+        } finally {
+            if (fileLocation.exists()) {
+                deleteRecursive(fileLocation);
+            }
+        }
+    }
+
+    private File getLocation(File fileLocation) {
+        String name = fileLocation.getAbsolutePath() + File.separator + FailedReporter.TESTNG_FAILED_XML;
+        return new File(name);
+    }
+
+    private File runTests(boolean simulateFailures) {
+        String suiteName = UUID.randomUUID().toString();
+        File fileLocation = new File(tempDir, suiteName);
+        if (! fileLocation.exists()) {
+            fileLocation.mkdirs();
+        }
+        TestNG testNG = new TestNG();
+        Class cls = FailedReporterLocalTestClass.WithoutFailure.class;
+        if (simulateFailures) {
+            cls = FailedReporterLocalTestClass.WithFailure.class;
+        }
+        testNG.setTestClasses(new Class[] {cls});
+        testNG.setOutputDirectory(fileLocation.getAbsolutePath());
+        try {
+            testNG.run();
+        } catch (AssertionError e) {
+            //catch all assertion failures. Our intent is not assertions of the test class.
+        }
+        return fileLocation;
+    }
+
+    private static void deleteRecursive(File path) {
+        if (! path.exists()) {
+            return;
+        }
+        if (path.isDirectory()) {
+            File[] files = path.listFiles();
+            if (null != files) {
+                for (File f : files) {
+                    deleteRecursive(f);
+                }
+            }
+        }
+        path.delete();
+
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -115,6 +115,7 @@
       <class name="test.parameters.ShadowTest" />
       <class name="test.parameters.ParameterOverrideTest" />
       <class name="test.reports.FailedReporterTest" />
+      <class name="test.failedreporter.FailedReporterScenariosTest"/>
       <class name="test.reports.ReporterLogTest" />
       <class name="test.testng387.TestNG387"/>
     </classes>


### PR DESCRIPTION
TestNG created the testng-failed.xml all the time 
whereas it should have created this file only when
there are no failures.

Fixed this problem by excluding copying of XmlTest
objects in the deep copy operation of XmlSuite.
Added a unit test so that this is now included as
part of the testing.