### PR TITLE
Issue #1197 Ability to dynamically set the status and exception of a test via ITestResult

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-﻿Current
+Current
+Fixed: GITHUB-1197: Ability to dynamically set the status and exception of a test via ITestResult (Anthony Nguyen)
 Fixed: GITHUB-1181: Fix MethodMatcherException: Data provider mismatch (Krishnan Mahadevan)
 Fixed: GITHUB-1107: TestNG does not report/print/log throwables in data providers (Krishnan Mahadevan)
 Fixed: GITHUB-1186: NullPointerException in JUnit reporter when used with Spock (Ian Robertson & Julien Herr)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -645,7 +645,11 @@ public class Invoker implements IInvoker {
             MethodInvocationHelper.invokeMethod(thisMethod, instance,
                 parameterValues);
           }
-          testResult.setStatus(ITestResult.SUCCESS);
+          // set the test to success as long as the testResult hasn't been changed by the user via
+          // Reporter.getCurrentTestResult
+          if (testResult.getStatus() == ITestResult.STARTED) {
+            testResult.setStatus(ITestResult.SUCCESS);
+          }
         } else {
           // Method with a timeout
           MethodInvocationHelper.invokeWithTimeout(tm, instance, parameterValues, testResult, hookableInstance);


### PR DESCRIPTION
Fixes #1197 .
### Did you remember to?
- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

Fix the ability to dynamically set the status and exception of a Test by
using Reporter.getCurrentTestResult
