### PR TITLE
issue-1365 fix

### DIFF
--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -34,7 +34,7 @@ public class Parser {
   public static final String DEFAULT_FILENAME = "testng.xml";
 
   private static final ISuiteParser DEFAULT_FILE_PARSER = new SuiteXmlParser();
-  private static final List<ISuiteParser> PARSERS = Lists.newArrayList(DEFAULT_FILE_PARSER);
+  private static final List<ISuiteParser> PARSERS = Lists.newArrayList();
   static {
     ServiceLoader<ISuiteParser> suiteParserLoader = ServiceLoader.load(ISuiteParser.class);
     for (ISuiteParser parser : suiteParserLoader) {


### PR DESCRIPTION
Fixes # 1365.
The fix will allow to use the default parser after checking if there is any other custom parser which may consume a test script.