### PR TITLE
@afterMethod, @afterGroup should be called if @beforeMethod throws exception with configfailurepolicy as continue.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Fixed: GITHUB-1360: TestNG does not distinguish between methods of different pri
 Fixed: GITHUB-1144: Add Class and Constructor as legal native dependency injection (Guillaume Juillot)
 Fixed: GITHUB-1380: Circular dependencies may fail in parallel (Julien Herr)
 Fixed: GITHUB-1400: TestNG, Multiple duplicate listener warnings on implementing multiple listener interfaces (@bipo1980 & Nick Tan)
+Fixed: GITHUB-1426: @afterMethod is not getting called if we have exception in @beforeMethod with configfailurepolicy as continue (@dipak-pawar)
 
 6.11
 2017/02/27

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -601,11 +601,20 @@ public class Invoker implements IInvoker {
       suite, params, parameterValues,
       instance, testResult);
 
+    InvokedMethod invokedMethod = new InvokedMethod(instance,
+        tm,
+        System.currentTimeMillis(),
+        testResult);
+
     if (!confInvocationPassed(tm, tm, testClass, instance)) {
       ITestResult result = registerSkippedTestResult(tm, instance, System.currentTimeMillis(),
               getExceptionDetails(instance));
       m_notifier.addSkippedTest(tm, result);
       tm.incrementCurrentInvocationCount();
+
+      runInvokedMethodListeners(InvokedMethodListenerMethod.AFTER_INVOCATION, invokedMethod, testResult);
+      invokeConfigurations(testClass, tm, this.filterConfigurationMethods(tm, afterMethods, false), suite, params, parameterValues, instance, testResult);
+      invokeAfterGroupsConfigurations(testClass, tm, groupMethods, suite, params, instance);
 
       return result;
     }
@@ -613,7 +622,6 @@ public class Invoker implements IInvoker {
     //
     // Create the ExtraOutput for this method
     //
-    InvokedMethod invokedMethod = null;
     try {
       testResult.init(testClass, instance,
                                  tm,
@@ -627,11 +635,6 @@ public class Invoker implements IInvoker {
       testResult.setStatus(ITestResult.STARTED);
 
       Reporter.setCurrentTestResult(testResult);
-
-      invokedMethod= new InvokedMethod(instance,
-          tm,
-          System.currentTimeMillis(),
-          testResult);
 
       // Fix from ansgarkonermann
       // invokedMethod is used in the finally, which can be invoked if

--- a/src/test/java/test/configurationfailurepolicy/ClassWithFailedBeforeMethodAndVerifyAfterMethodAfterGroup.java
+++ b/src/test/java/test/configurationfailurepolicy/ClassWithFailedBeforeMethodAndVerifyAfterMethodAfterGroup.java
@@ -1,0 +1,36 @@
+package test.configurationfailurepolicy;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ClassWithFailedBeforeMethodAndVerifyAfterMethodAfterGroup {
+
+    static boolean tearDown = false;
+    static boolean afterGroup = false;
+
+    @BeforeMethod
+    public void setupShouldFail() {
+        throw new RuntimeException("Failing in setUp");
+    }
+
+    @Test(groups = "group1")
+    public void test1() {
+
+    }
+
+    @AfterMethod
+    public void tearDownShouldCall() {
+        tearDown = true;
+    }
+
+    @AfterGroups(groups = "group1")
+    public void groupShouldCall(){
+        afterGroup = true;
+    }
+
+    static boolean sucess() {
+        return tearDown && afterGroup;
+    }
+}

--- a/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
+++ b/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
@@ -3,6 +3,7 @@ package test.configurationfailurepolicy;
 import static org.testng.Assert.assertEquals;
 import static test.SimpleBaseTest.getPathToResource;
 
+import org.testng.Assert;
 import org.testng.ITestContext;
 import org.testng.ITestNGListener;
 import org.testng.TestListenerAdapter;
@@ -76,6 +77,17 @@ public class FailurePolicyTest {
     TestNG.privateMain(argv, tla);
 
     verify(tla, 2, 0, 2);
+  }
+
+  @Test
+  public void shouldCall_afterMethod_and_afterGroup_for_commandLineTest_policyAsContinue() {
+    String[] argv = new String[] { "-log", "0", "-d", OutputDirectoryPatch.getOutputDirectory(),
+        "-configfailurepolicy", "continue",
+        "-testclass", ClassWithFailedBeforeMethodAndVerifyAfterMethodAfterGroup.class.getCanonicalName() };
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG.privateMain(argv, tla);
+
+    Assert.assertTrue(ClassWithFailedBeforeMethodAndVerifyAfterMethodAfterGroup.sucess());
   }
 
   @Test


### PR DESCRIPTION
Fixes  #1426

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

