### PR TITLE
Fixed issue with TestNG not getting garbage collected. See #1461

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1142,6 +1142,9 @@ public class TestNG {
         usage();
       }
     }
+
+    m_instance = null;
+    m_jCommander = null;
   }
 
   /**

--- a/src/test/java/test/github1461/MemoryLeakTestNg.java
+++ b/src/test/java/test/github1461/MemoryLeakTestNg.java
@@ -1,0 +1,102 @@
+package test.github1461;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+
+/**
+ * This class reproduces a memory leak problem when running TestNG tests.
+ * The same (memory behavior will be shown when running this test as normal TestNG test (e.g. using Intellij)
+ *
+ * See https://github.com/cbeust/testng/issues/1461
+ */
+public class MemoryLeakTestNg {
+
+    public static void main(String[] args) throws Exception {
+
+        // we run the test programmatically
+        runTest();
+        // lets wait for garbage collection
+        waitForAllObjectsDestructed();
+    }
+
+    public static void waitForAllObjectsDestructed() throws InterruptedException {
+        while (true) {
+            System.out.println("waiting for clean up...");
+            // enforce a full gc
+            System.gc();
+
+            // check if there are still instances of our test class
+            if (MyTestClassWithGlobalReferenceCounter.currentNumberOfMyTestObjects == 0) {
+                // if we reach this point, all test instances are gone,
+                // ... however this never happens ...
+                break;
+            }
+            // let's wait 5 seconds and try again ...
+            Thread.sleep(1000);
+            System.out.println("[" + MyTestClassWithGlobalReferenceCounter.currentNumberOfMyTestObjects + "] test object(s) still exist.");
+        }
+    }
+
+    private static void runTest() {
+
+        // create TestNG class
+        TestNG testng = new TestNG() {
+            @Override
+            protected void finalize() throws Throwable {
+                // it seems that this object will never be finalized !!!
+                System.out.println("TestNG finalized");
+            }
+        };
+
+
+        // and set a test (which also will never be finalized ... see later)
+        testng.setTestClasses(new Class[]{
+            MyTestClassWithGlobalReferenceCounter.class,
+        });
+
+        // lets run the test
+        testng.run();
+
+        // At this point the test run through and we expect both instances
+        // - testng and
+        // - the test object of type (MyTest)
+        // will be garbage collected when leaving this method
+        // ...
+
+    }
+
+    /**
+     * we create a test NG class here, which has a global counter, counting all instances.
+     */
+    public static class MyTestClassWithGlobalReferenceCounter {
+
+        /**
+         * global counter that keeps track on how many objects are currently on the heap
+         */
+        public static int currentNumberOfMyTestObjects = 0;
+
+        public MyTestClassWithGlobalReferenceCounter() {
+            System.out.println("constructor");
+            // increase the counter
+            ++currentNumberOfMyTestObjects;
+        }
+
+        @Test
+        public void aTestMethod1() {
+            System.out.println("test method 1");
+        }
+
+        @Test
+        public void aTestMethod2() {
+            System.out.println("test method 2");
+        }
+
+
+        @Override
+        protected void finalize() throws Throwable {
+            System.out.println("finalize");
+            // this will be called when this object is removed from the heap
+            --currentNumberOfMyTestObjects;
+        }
+    }
+}

--- a/src/test/java/test/github1471/TestNgEnableBehaviour.java
+++ b/src/test/java/test/github1471/TestNgEnableBehaviour.java
@@ -1,0 +1,42 @@
+package test.github1471;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+import test.enable.InvokedMethodListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test test should ensure that disabled tests are not executed.
+ * See issue: https://github.com/cbeust/testng/issues/1471
+ *
+ * @author Kirusanth Poopalasingam ( code@kiru.io )
+ */
+public class TestNgEnableBehaviour extends SimpleBaseTest{
+
+    @Test
+    public void disabled_test() {
+        TestNG tng = create(TestA.class, TestDisabled.class);
+        InvokedMethodListener listener = new InvokedMethodListener();
+        tng.addListener(listener);
+        tng.setPreserveOrder(true);
+        tng.run();
+
+        assertThat(listener.getInvokedMethods()).containsExactly(
+            "testATestMethod"
+        );
+    }
+
+    @Test(enabled = false)
+    public static class TestDisabled {
+        @Test
+        public void testDisabledTestMethod() {}
+    }
+
+    @Test
+    public static class TestA {
+        @Test
+        public void testATestMethod() {}
+    }
+}


### PR DESCRIPTION
This change should allow JVM to GC the TestNG instance after tests are completed. 
