### PR TITLE
Should version in build.gradle be moved up...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ task wrapper(type: Wrapper) {
 }
 
 group = 'org.testng'
-version = '6.11.1-SNAPSHOT'
+version = '6.12.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'groovy'


### PR DESCRIPTION
Should version in build.gradle be moved up to 6.12, to match the value in Build.kt?

Signed-off-by: nickboldt <nboldt@redhat.com>