### PR TITLE
Fix for 1077 and 1081

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current
-Fixed: Updated MethodHelper topologicalSort to method dependencies more efficiently (Aheiss)
+Fixed: GITHUB-1077 GITHUB-1081: Updated MethodHelper topologicalSort to method dependencies more efficiently (Aheiss)
 Fixed: GITHUB-1688: @Ignore annotation on base class doesn't ignore tests in child classes (Krishnan Mahadevan)
 Fixed: GITHUB-1687: NullPointerException is thrown when beanshell evaluates to null (Krishnan Mahadevan)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: Updated MethodHelper topologicalSort to method dependencies more efficiently (Aheiss)
 Fixed: GITHUB-1688: @Ignore annotation on base class doesn't ignore tests in child classes (Krishnan Mahadevan)
 Fixed: GITHUB-1687: NullPointerException is thrown when beanshell evaluates to null (Krishnan Mahadevan)
 

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -261,7 +261,7 @@ public class MethodHelper {
       if (groupsDependedUpon.length > 0) {
         for (String group : groupsDependedUpon) {
           ITestNGMethod[] methodsThatBelongToGroup =
-             MethodGroupsHelper.findMethodsThatBelongToGroup(m, methods, group);
+            MethodGroupsHelper.findMethodsThatBelongToGroup(m, methods, group);
           for (ITestNGMethod pred : methodsThatBelongToGroup) {
             predecessors.add(pred);
           }


### PR DESCRIPTION
Fixed toplologicalSort to be more efficient for depends on method sorting

This fix reduces the scope of MethodHelper toplologicalSort to be more efficient. The search scope for "methoddependedupon" was changed from all methods with "dependsOnMethods" tag to just methods that share the same instance. If a method has an instance of null then all methods are still searched. In my testing this provided a massive decrease in load time for large suites that group by method.

Fixes #1077 and #1081 

### Did you remember to?

- [ ] Add test case(s) - Existing test cases cover changes.
- [ x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
