### PR TITLE
Add ability to create new instance per test method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New  : Added ability to create a new instance per test method. (Jason Corbett)
 Fixed: GITHUB-1863: IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way.(Bin Wu)
 Fixed: GITHUB-1865: testngXmlPathInJar- cannot be cleared when vm terminate(Yehui Wang)
 Fixed: GITHUB-1850: Parser returns a wrong structure when parent suite has duplicate child suites (Chao Qin)

--- a/src/main/java/org/testng/annotations/NewInstancePerMethod.java
+++ b/src/main/java/org/testng/annotations/NewInstancePerMethod.java
@@ -1,0 +1,16 @@
+package org.testng.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * Marking a class with this tells TestNG to use a new instance of the class per test method.  You can also do this
+ * globally with a system property (testng.newInstancePerMethod) or environment variable
+ * "TESTNG_NEW_INSTANCE_PER_METHOD".
+ */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target(TYPE)
+public @interface NewInstancePerMethod {
+}

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -31,6 +31,7 @@ import org.testng.SuiteRunState;
 import org.testng.TestException;
 import org.testng.TestNGException;
 import org.testng.annotations.IConfigurationAnnotation;
+import org.testng.annotations.NewInstancePerMethod;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
@@ -579,6 +580,17 @@ public class Invoker implements IInvoker {
       ITestNGMethod[] afterMethods,
       ConfigurationGroupMethods groupMethods,
       FailureContext failureContext) {
+
+    if(System.getProperties().containsKey("testng.newInstancePerMethod") ||
+       System.getenv().containsKey("TESTNG_NEW_INSTANCE_PER_METHOD") ||
+       instance.getClass().isAnnotationPresent(NewInstancePerMethod.class)) {
+      try {
+        instance = ClassHelper.newInstance(instance.getClass());
+      } catch (TestNGException e) {
+        e.printStackTrace();
+      }
+    }
+
     TestResult testResult = new TestResult();
 
     invokeBeforeGroupsConfigurations(tm, groupMethods, suite, params, instance);

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -584,10 +584,22 @@ public class Invoker implements IInvoker {
     if(System.getProperties().containsKey("testng.newInstancePerMethod") ||
        System.getenv().containsKey("TESTNG_NEW_INSTANCE_PER_METHOD") ||
        instance.getClass().isAnnotationPresent(NewInstancePerMethod.class)) {
-      try {
-        instance = ClassHelper.newInstance(instance.getClass());
-      } catch (TestNGException e) {
-        e.printStackTrace();
+      boolean tryConstructor = true;
+      if (Cloneable.class.isAssignableFrom(instance.getClass())) {
+        try {
+          instance = instance.getClass().getDeclaredMethod("clone").invoke(instance);
+          tryConstructor = false;
+        } catch (NoSuchMethodException e) {
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
+        }
+      }
+      if(tryConstructor) {
+        try {
+          instance = ClassHelper.newInstance(instance.getClass());
+        } catch (TestNGException e) {
+          e.printStackTrace();
+        }
       }
     }
 

--- a/src/test/java/test/newinstancepermethod/CloneableTest.java
+++ b/src/test/java/test/newinstancepermethod/CloneableTest.java
@@ -1,0 +1,21 @@
+package test.newinstancepermethod;
+
+import org.testng.Assert;
+import org.testng.annotations.NewInstancePerMethod;
+import org.testng.annotations.Test;
+
+@NewInstancePerMethod
+public class CloneableTest implements Cloneable {
+    private boolean member = false;
+
+    public Object clone() {
+        CloneableTest clone = new CloneableTest();
+        clone.member = true;
+        return clone;
+    }
+
+    @Test
+    public void checkCloningWorked() {
+        Assert.assertTrue(member, "A cloned test should have made the member be true.");
+    }
+}

--- a/src/test/java/test/newinstancepermethod/NewInstancePerMethodTests.java
+++ b/src/test/java/test/newinstancepermethod/NewInstancePerMethodTests.java
@@ -1,0 +1,74 @@
+package test.newinstancepermethod;
+
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import java.util.Arrays;
+
+public class NewInstancePerMethodTests {
+    @Test
+    public void testParallelAttributes() {
+        XmlSuite suite = new XmlSuite();
+        suite.setName("TestParallelAttributes");
+        XmlTest test = new XmlTest(suite);
+        test.setParallel(XmlSuite.ParallelMode.METHODS);
+        test.setThreadCount(6);
+        test.getXmlClasses().add(new XmlClass(ParallelAttributeTest.class.getName(), 0, true));
+        TestNG result = new TestNG();
+        result.setUseDefaultListeners(false);
+        result.setVerbose(0);
+        result.setXmlSuites(Arrays.asList(suite));
+        TestListenerAdapter tla = new TestListenerAdapter();
+        result.addListener(tla);
+        result.run();
+        Assert.assertEquals(tla.getFailedTests().size(), 0, "Each test method did not recieve it's own instance. ");
+    }
+
+    @Test
+    public void testSerialModificationWithSystemProperty() {
+        boolean modified = false;
+        if(!System.getProperties().containsKey("testng.newInstancePerMethod")) {
+            System.getProperties().put("testng.newInstancePerMethod", "true");
+            modified = true;
+        }
+        XmlSuite suite = new XmlSuite();
+        suite.setName("TestSerialModification");
+        XmlTest test = new XmlTest(suite);
+        test.getXmlClasses().add(new XmlClass(SerialMemberModificationTest.class.getName(), 0, true));
+        TestNG result = new TestNG();
+        result.setUseDefaultListeners(false);
+        result.setVerbose(0);
+        result.setXmlSuites(Arrays.asList(suite));
+        TestListenerAdapter tla = new TestListenerAdapter();
+        result.addListener(tla);
+        result.run();
+        try {
+            Assert.assertEquals(tla.getFailedTests().size(), 0, "Each test method did not receive it's own instance. ");
+        } finally {
+            if(modified) {
+                System.getProperties().remove("testng.newInstancePerMethod");
+            }
+        }
+    }
+
+    @Test
+    public void testClonable() {
+        XmlSuite suite = new XmlSuite();
+        suite.setName("CloneableTest");
+        XmlTest test = new XmlTest(suite);
+        test.getXmlClasses().add(new XmlClass(CloneableTest.class.getName(), 0, true));
+        TestNG result = new TestNG();
+        result.setUseDefaultListeners(false);
+        result.setVerbose(0);
+        result.setXmlSuites(Arrays.asList(suite));
+        TestListenerAdapter tla = new TestListenerAdapter();
+        result.addListener(tla);
+        result.run();
+        Assert.assertEquals(tla.getFailedTests().size(), 0, "Each test method did not receive it's own instance. ");
+    }
+}

--- a/src/test/java/test/newinstancepermethod/ParallelAttributeTest.java
+++ b/src/test/java/test/newinstancepermethod/ParallelAttributeTest.java
@@ -1,0 +1,56 @@
+package test.newinstancepermethod;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.NewInstancePerMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@NewInstancePerMethod
+public class ParallelAttributeTest {
+        private int member;
+        private ThreadLocal<Integer> expected = new ThreadLocal<>();
+
+        @BeforeMethod
+        public void setup() {
+            member = ThreadLocalRandom.current().nextInt(1, 51);
+            expected.set(member);
+        }
+
+        @Test
+        public void first() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+
+        @Test
+        public void second() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+
+        @Test
+        public void third() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+
+        @Test
+        public void fourth() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+
+        @Test
+        public void fifth() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+
+        @Test
+        public void sixth() throws Exception {
+            Thread.sleep(ThreadLocalRandom.current().nextLong(100, 800));
+            Assert.assertEquals(member, expected.get().intValue(), "member variable and thread local do not match");
+        }
+}

--- a/src/test/java/test/newinstancepermethod/SerialMemberModificationTest.java
+++ b/src/test/java/test/newinstancepermethod/SerialMemberModificationTest.java
@@ -1,0 +1,27 @@
+package test.newinstancepermethod;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SerialMemberModificationTest {
+    private int member = 42;
+
+
+    @Test
+    public void fistTest() {
+        try {
+            Assert.assertEquals(member, 42);
+        } finally {
+            member++;
+        }
+    }
+
+    @Test
+    public void secondTest() {
+        try {
+            Assert.assertEquals(member, 42);
+        } finally {
+            member++;
+        }
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -911,5 +911,11 @@
     </classes>
   </test>
 
+  <test name="New Instance Per Method tests">
+    <classes>
+      <class name="test.newinstancepermethod.NewInstancePerMethodTests"/>
+    </classes>
+  </test>
+
 </suite>
 

--- a/src/test/resources/testng.yaml
+++ b/src/test/resources/testng.yaml
@@ -68,7 +68,7 @@ tests:
       - test.regression.BeforeTestFailingTest
       - test.testng285.TestNG285Test
       - test.failedreporter.FailedReporterTest
-      - test.attributes.AttributeTest
+      - test.attributes.ParallelAttributeTest
       - test.verify.VerifyTest
       - test.abstractconfmethod.C
       - test.issue78.NonPublicClassTest


### PR DESCRIPTION
Fixes #1872 

While not always useful, the ability to have each method have it's own instance to avoid member variables becoming corrupted helps, particularly in parallel=methods.  This allows the tester to selectively specify (including at the class level) when this is useful.

It should work with factories if they implement Cloneable and provide a clone method.  I wanted to find a way to implement this when loading tests, but it seemed difficult or impossible.  So this is implemented at the point when the test runs. 

Some features of testng are incompatible with this feature (BeforeClass that modifies the instance).  

If there is a better way to accomplish this please let me know.