### PR TITLE
A new extension of SkipException to support retry check when exception happened

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2107: A new extension of SkipException to support retry check when exception happened (Yehui Wang)
 Fixed: GITHUB-2069: JUnit TestSuite not handled correctly in Reports (Krishnan Mahadevan)
 Fixed: GITHUB-2075: Thread interrupt flag persists between test methods (Krishnan Mahadevan)
 Fixed: GITHUB-2074: Thread Interrupted when using expectedException (Krishnan Mahadevan)

--- a/src/main/java/org/testng/SkipWithRetryCheckException.java
+++ b/src/main/java/org/testng/SkipWithRetryCheckException.java
@@ -1,0 +1,44 @@
+package org.testng;
+
+import org.testng.Reporter;
+import org.testng.SkipException;
+import org.testng.internal.annotations.DisabledRetryAnalyzer;
+
+/**
+ * A {@link SkipException} extension that transforms a skipped test method into a failed method, if field {@code checkRerun} is 
+ * set as true, meanwhile test method has customized retryAnalyzer. 
+ */
+public class SkipWithRetryCheckException extends SkipException {
+    
+    private static final long serialVersionUID = 1233817787139806976L;
+    private volatile boolean checkRerun = true;
+    
+    public SkipWithRetryCheckException(String skipMessage) {
+      this(skipMessage, true);
+    }
+
+    public SkipWithRetryCheckException(String skipMessage, Throwable cause) {
+      this(skipMessage, cause, true);
+    }
+    
+    public SkipWithRetryCheckException(String skipMessage, boolean checkRerun) {
+      super(skipMessage);
+      this.checkRerun = checkRerun;
+    }
+    
+    public SkipWithRetryCheckException(String skipMessage, Throwable cause, boolean checkRerun) {
+      super(skipMessage, cause);
+      this.checkRerun = checkRerun;
+    }
+
+    @Override
+    public boolean isSkip() {
+      ITestResult currentTestResult = Reporter.getCurrentTestResult();
+      if((this.checkRerun)&&(currentTestResult != null)&&(!currentTestResult.getMethod().getRetryAnalyzer(currentTestResult).getClass()
+              .getSimpleName().equals(DisabledRetryAnalyzer.class.getSimpleName()))) {
+        return false;
+      }
+      return true;
+    }
+
+}

--- a/src/main/java/org/testng/TestListenerAdapter.java
+++ b/src/main/java/org/testng/TestListenerAdapter.java
@@ -1,5 +1,6 @@
 package org.testng;
 
+import org.testng.collections.Lists;
 import org.testng.collections.Objects;
 import org.testng.internal.IResultListener2;
 
@@ -140,6 +141,16 @@ public class TestListenerAdapter implements IResultListener2 {
 
   public List<ITestResult> getConfigurationSkips() {
     return new ArrayList<>(m_skippedConfs);
+  }
+
+  public List<ITestResult> getRetriedTests(){
+    List<ITestResult> testResults = Lists.newArrayList();
+    for(ITestResult result : getSkippedTests()) {
+      if(result.wasRetried()) {
+          testResults.add(result);
+      }
+    }
+    return testResults;
   }
 
   @Override

--- a/src/test/java/test/retryAnalyzer/retrywithskip/AddReryWithTransformer.java
+++ b/src/test/java/test/retryAnalyzer/retrywithskip/AddReryWithTransformer.java
@@ -1,0 +1,18 @@
+package test.retryAnalyzer.retrywithskip;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import org.testng.IAnnotationTransformer;
+import org.testng.IRetryAnalyzer;
+import org.testng.annotations.ITestAnnotation;
+import org.testng.internal.annotations.DisabledRetryAnalyzer;
+
+public class AddReryWithTransformer implements IAnnotationTransformer{
+    @Override
+    public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
+        Class<? extends IRetryAnalyzer> retry = annotation.getRetryAnalyzerClass();
+        if (retry.getSimpleName().equals(DisabledRetryAnalyzer.class.getSimpleName())) {
+            annotation.setRetryAnalyzer(SimpleRetryAnalyzer.class);
+        }
+    }
+}

--- a/src/test/java/test/retryAnalyzer/retrywithskip/RerunTest1.java
+++ b/src/test/java/test/retryAnalyzer/retrywithskip/RerunTest1.java
@@ -1,0 +1,18 @@
+package test.retryAnalyzer.retrywithskip;
+
+import org.testng.SkipWithRetryCheckException;
+import org.testng.annotations.Test;
+
+public class RerunTest1 {   
+    
+    @Test
+    public void test1() {        
+        throw new SkipWithRetryCheckException("", false);        
+    }
+    
+    @Test
+    public void test2() {        
+        throw new SkipWithRetryCheckException("");        
+    }
+
+}

--- a/src/test/java/test/retryAnalyzer/retrywithskip/RerunTest2.java
+++ b/src/test/java/test/retryAnalyzer/retrywithskip/RerunTest2.java
@@ -1,0 +1,23 @@
+package test.retryAnalyzer.retrywithskip;
+
+import org.testng.SkipWithRetryCheckException;
+import org.testng.annotations.Test;
+
+public class RerunTest2 {
+    
+    @Test
+    public void test1() {        
+        throw new SkipWithRetryCheckException("", false);        
+    }
+    
+    @Test(retryAnalyzer = SimpleRetryAnalyzer.class)
+    public void test2() {        
+        throw new SkipWithRetryCheckException("");        
+    }
+    
+    @Test
+    public void test3() {        
+        throw new SkipWithRetryCheckException("");        
+    }
+
+}

--- a/src/test/java/test/retryAnalyzer/retrywithskip/RetrySkipTest.java
+++ b/src/test/java/test/retryAnalyzer/retrywithskip/RetrySkipTest.java
@@ -1,0 +1,35 @@
+package test.retryAnalyzer.retrywithskip;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class RetrySkipTest extends SimpleBaseTest {
+    
+    @Test
+    public void test1() {
+        TestNG testng = create(RerunTest1.class);
+        testng.addListener(new AddReryWithTransformer());
+        TestListenerAdapter adapter  = new TestListenerAdapter();
+        testng.addListener(adapter);
+        testng.run();
+        assertEquals(
+                adapter.getRetriedTests().size(),
+                1,
+                "wrong number of retried test case");
+    }
+    
+    @Test
+    public void test2() {
+        TestNG testng = create(RerunTest2.class);
+        TestListenerAdapter adapter  = new TestListenerAdapter();
+        testng.addListener(adapter);
+        testng.run();        
+        assertEquals(
+                adapter.getRetriedTests().size(),
+                1,
+                "wrong number of retried test case");
+    }
+}

--- a/src/test/java/test/retryAnalyzer/retrywithskip/SimpleRetryAnalyzer.java
+++ b/src/test/java/test/retryAnalyzer/retrywithskip/SimpleRetryAnalyzer.java
@@ -1,0 +1,17 @@
+package test.retryAnalyzer.retrywithskip;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class SimpleRetryAnalyzer implements IRetryAnalyzer {
+    private static int counts = 1;
+    @Override
+    public boolean retry(ITestResult result) {
+        if(counts -- > 0) {
+            return true;
+        }else {
+            counts = 1 ;
+            return false;
+        }
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -711,6 +711,7 @@
       <class name="test.retryAnalyzer.RetryAnalyzerTest" />
       <class name="test.retryAnalyzer.ExitCodeTest" />
       <class name="test.retryAnalyzer.dataprovider.RetryAnalyzerWithDataProviderTest" />
+      <class name="test.retryAnalyzer.retrywithskip.RetrySkipTest" />
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes #2107 
Closes #2107 

Add a new extension of SkipException, to let it support to retry when skip exception happened, when met following conditions:

1. There is a field to control retry check turned on/off when skip exception happened.
2. Retry with skip only support at test method, not configuration method.
3. Implementation of IRetryAnalyzer is added for this test method.