### PR TITLE
Fixed an issue wher case timeout returned an incorrect exception

### DIFF
--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -332,7 +332,7 @@ public class MethodInvocationHelper {
         testResult.setStatus(ITestResult.FAILURE);
       }
     } catch (Exception ex) {
-      if (notTimedout && !Thread.interrupted()) {
+      if (notTimedout && !Thread.currentThread().isInterrupted()) {
         Throwable e = ex.getCause();
         if (e instanceof TestNGRuntimeException) {
           e = e.getCause();

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -304,6 +304,7 @@ public class MethodInvocationHelper {
     long realTimeOut = MethodHelper.calculateTimeOut(tm);
     boolean notTimedout = true;
     AtomicBoolean finished = new AtomicBoolean(false);
+    AtomicBoolean isInterruptByThread = new AtomicBoolean(false);
     try {
       Thread currentThread = Thread.currentThread();
       new Thread(() -> {
@@ -313,6 +314,7 @@ public class MethodInvocationHelper {
           Thread.currentThread().interrupt();
         }
         if (!finished.get()){
+          isInterruptByThread.set(true);
           currentThread.interrupt();
         }
       }).start();
@@ -332,7 +334,7 @@ public class MethodInvocationHelper {
         testResult.setStatus(ITestResult.FAILURE);
       }
     } catch (Exception ex) {
-      if (notTimedout && !Thread.currentThread().isInterrupted()) {
+      if (notTimedout && !isInterruptByThread.get()) {
         Throwable e = ex.getCause();
         if (e instanceof TestNGRuntimeException) {
           e = e.getCause();

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -34,6 +34,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Collections of helper methods to help deal with invocation of TestNG methods
  */
@@ -301,6 +303,7 @@ public class MethodInvocationHelper {
     long startTime = System.currentTimeMillis();
     long realTimeOut = MethodHelper.calculateTimeOut(tm);
     boolean notTimedout = true;
+    AtomicBoolean finished = new AtomicBoolean(false);
     try {
       Thread currentThread = Thread.currentThread();
       new Thread(() -> {
@@ -309,7 +312,9 @@ public class MethodInvocationHelper {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
-        currentThread.interrupt();
+        if (!finished.get()){
+          currentThread.interrupt();
+        }
       }).start();
       imr.run();
       notTimedout = System.currentTimeMillis() <= startTime + realTimeOut;
@@ -344,6 +349,8 @@ public class MethodInvocationHelper {
         testResult.setThrowable(exception);
       }
       testResult.setStatus(ITestResult.FAILURE);
+    } finally {
+      finished.set(true);
     }
   }
 

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -327,7 +327,7 @@ public class MethodInvocationHelper {
         testResult.setStatus(ITestResult.FAILURE);
       }
     } catch (Exception ex) {
-      if (notTimedout) {
+      if (notTimedout && !Thread.interrupted()) {
         Throwable e = ex.getCause();
         if (e instanceof TestNGRuntimeException) {
           e = e.getCause();


### PR DESCRIPTION
Fixes 
The current judgment condition causes the exception result to InterruptedException instead of the expected ThreadTimeoutException after the method call timeout is interrupted.

So I call Thread.interrupted() to ensure that the correct exception type is returned, while restoring the interrupt status value of Thread so that its subsequent operations are unaffected.

If you want to reproduce this problem, please make sure to create a new TestNG object through Java and set ParallelMode to any non-Tests