### PR TITLE
Fix bux where Strings.join returns empty String

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2465: Fix bux where Strings.join returns empty String
 Fixed: GITHUB-1632: throwing SkipException sets iTestResult status to Failure instead of Skip (Julien Herr & Krishnan Mahadevan)
 New  : GITHUB-2456: Add onDataProviderFailure listener (Krishnan Mahadevan)
 Fixed: GITHUB-2445: NPE in FailedReporter.java With Tests Created in Factory (Arham Jain)

--- a/src/main/java/org/testng/util/Strings.java
+++ b/src/main/java/org/testng/util/Strings.java
@@ -67,7 +67,7 @@ public final class Strings {
     for (int i = 0; i < parts.length - 1; i++) {
       sb.append(parts[i]).append(delimiter);
     }
-    if (parts.length > 1) {
+    if (parts.length > 0) {
       sb.append(parts[parts.length - 1]);
     }
     return sb.toString();

--- a/src/test/java/org/testng/util/StringsTest.java
+++ b/src/test/java/org/testng/util/StringsTest.java
@@ -1,0 +1,30 @@
+package org.testng.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link Strings}
+ *
+ * @author Spencer Gilson
+ */
+public class StringsTest {
+    @Test
+    public void joinEmptyArray() {
+        String[] emptyArray = new String[0];
+        assertEquals(Strings.join(",", emptyArray), "");
+    }
+
+    @Test
+    public void joinArrayWithOneElement() {
+        String[] array = new String[]{"one"};
+        assertEquals(Strings.join(",", array), "one");
+    }
+
+    @Test
+    public void joinArrayWithTwoElements() {
+        String[] array = new String[]{"one", "two"};
+        assertEquals(Strings.join(",", array), "one,two");
+    }
+}

--- a/src/test/java/org/testng/util/StringsTest.java
+++ b/src/test/java/org/testng/util/StringsTest.java
@@ -6,8 +6,6 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * Unit tests for {@link Strings}
- *
- * @author Spencer Gilson
  */
 public class StringsTest {
     @Test

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -767,6 +767,7 @@
       <class name="org.testng.internal.UtilsTest" />
       <class name="org.testng.internal.ClassHelperTest"/>
       <class name="org.testng.internal.InstanceCreatorTest"/>
+      <class name="org.testng.util.StringsTest"/>
       <class name="test.issue1430.TestFileToClass"/>
     </classes>
   </test>


### PR DESCRIPTION
When Strings.join is given an array with length of 1, it returns an empty String instead of the first element.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`