### PR TITLE
Filter out null parameters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixes: GITHUB-2493: Avoid NPE from TextReporter execution when a dataprovider method provides null (baflQA)
 Fixed: GITHUB-2483: Asymmetric not equals (cdalexndr)
 Fixed: GITHUB-2486: assertSame/assertNotSame broken after GITHUB-2296 (Vitalii Diravka)
 

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -26,6 +26,8 @@ import org.testng.collections.Lists;
 import org.testng.log4testng.Logger;
 import org.testng.reporters.XMLStringBuffer;
 
+import static java.util.Objects.isNull;
+
 /** Helper methods to parse annotations. */
 public final class Utils {
 
@@ -608,8 +610,9 @@ public final class Utils {
 
   public static Class<?>[] extractParameterTypes(Object[] objects) {
     return Arrays.stream(objects)
-        .map(Object::getClass)
-        .toArray(Class<?>[]::new);
+            .filter(o -> !isNull(o))
+            .map(Object::getClass)
+            .toArray(Class<?>[]::new);
   }
 
   public static String stringifyTypes(Class<?>[] parameterTypes) {

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -26,7 +26,6 @@ import org.testng.collections.Lists;
 import org.testng.log4testng.Logger;
 import org.testng.reporters.XMLStringBuffer;
 
-
 /** Helper methods to parse annotations. */
 public final class Utils {
 

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -608,12 +608,6 @@ public final class Utils {
     return result;
   }
 
-  public static Class<?>[] extractParameterTypes(Object[] objects) {
-    return Arrays.stream(objects)
-            .map((Object o) -> o != null ? o.getClass(): null)
-            .toArray(Class<?>[]::new);
-  }
-
   public static String stringifyTypes(Class<?>[] parameterTypes) {
     return Arrays.stream(parameterTypes)
         .map(Class::getName)

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -26,7 +26,6 @@ import org.testng.collections.Lists;
 import org.testng.log4testng.Logger;
 import org.testng.reporters.XMLStringBuffer;
 
-import static java.util.Objects.isNull;
 
 /** Helper methods to parse annotations. */
 public final class Utils {

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -610,8 +610,7 @@ public final class Utils {
 
   public static Class<?>[] extractParameterTypes(Object[] objects) {
     return Arrays.stream(objects)
-            .filter(o -> !isNull(o))
-            .map(Object::getClass)
+            .map((Object o) -> o != null ? o.getClass(): null)
             .toArray(Class<?>[]::new);
   }
 

--- a/src/main/java/org/testng/reporters/TextReporter.java
+++ b/src/main/java/org/testng/reporters/TextReporter.java
@@ -55,7 +55,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           stackTrace,
           tr.getParameters(),
-          Utils.extractParameterTypes(tr.getParameters()));
+          tr.getMethod().getParameterTypes());
     }
 
     results = context.getSkippedConfigurations().getAllResults();
@@ -66,7 +66,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           null,
           tr.getParameters(),
-          Utils.extractParameterTypes(tr.getParameters()));
+          tr.getMethod().getParameterTypes());
     }
 
     results = context.getPassedTests().getAllResults();
@@ -137,7 +137,7 @@ public class TextReporter implements ITestListener {
         tr.getMethod().getDescription(),
         stackTrace,
         tr.getParameters(),
-        Utils.extractParameterTypes(tr.getParameters()));
+        tr.getMethod().getParameterTypes());
   }
 
   private void logExceptions(String status, List<ITestResult> results) {

--- a/src/main/java/org/testng/reporters/VerboseReporter.java
+++ b/src/main/java/org/testng/reporters/VerboseReporter.java
@@ -184,7 +184,7 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
     int identLevel = sb.length();
     sb.append(getMethodDeclaration(tm, itr));
     Object[] params = itr.getParameters();
-    Class<?>[] paramTypes = Utils.extractParameterTypes(itr.getParameters());
+    Class<?>[] paramTypes = itr.getMethod().getParameterTypes();
     if (null != params && params.length > 0) {
       // The error might be a data provider parameter mismatch, so make
       // a special case here
@@ -265,7 +265,7 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
       buf.append(Utils.annotationFormFor(method)).append(" ");
     }
     buf.append(method.getQualifiedName());
-    Class<?>[] objects = Utils.extractParameterTypes(tr.getParameters());
+    Class<?>[] objects = tr.getMethod().getParameterTypes();
     buf.append("(").append(Utils.stringifyTypes(objects)).append(")");
     return buf.toString();
   }

--- a/src/test/java/test/reports/ReportTest.java
+++ b/src/test/java/test/reports/ReportTest.java
@@ -261,11 +261,11 @@ public class ReportTest extends SimpleBaseTest {
   public static class NullParameter {
     @DataProvider
     public static Object[][] nullProvider() {
-      return new Object[][]{{null}};
+      return new Object[][]{{null, "Bazinga!"}};
     }
 
     @Test(dataProvider = "nullProvider")
-    public void testMethod(Object object) {
+    public void testMethod(Object nullReference, String bazinga) {
     }
   }
 
@@ -295,6 +295,6 @@ public class ReportTest extends SimpleBaseTest {
     tng.run();
     System.setOut(previousOut);
 
-    Assert.assertTrue(systemOutCapture.toString().contains("PASSED: testMethod(null)"));
+    Assert.assertTrue(systemOutCapture.toString().contains("PASSED: testMethod(null, \"Bazinga!\")"));
   }
 }

--- a/src/test/java/test/reports/ReportTest.java
+++ b/src/test/java/test/reports/ReportTest.java
@@ -258,8 +258,19 @@ public class ReportTest extends SimpleBaseTest {
     }
   }
 
+  public static class NullParameter {
+    @DataProvider
+    public static Object[][] nullProvider() {
+      return new Object[][]{{null}};
+    }
+
+    @Test(dataProvider = "nullProvider")
+    public void testMethod(Object object) {
+    }
+  }
+
   @Test
-  public void reportArraysToString() throws IOException {
+  public void reportArraysToString() {
     TestNG tng = create(DpArrays.class);
     tng.addListener(new TextReporter("name", 2));
 
@@ -271,5 +282,19 @@ public class ReportTest extends SimpleBaseTest {
 
     Assert.assertTrue(systemOutCapture.toString().contains("testMethod([ITEM1])"));
     Assert.assertTrue(systemOutCapture.toString().contains("testMethod([ITEM1, ITEM2])"));
+  }
+
+  @Test
+  public void reportCreatedWithNullParameter() {
+    TestNG tng = create(NullParameter.class);
+    tng.addListener(new TextReporter("name", 2));
+
+    PrintStream previousOut = System.out;
+    ByteArrayOutputStream systemOutCapture = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(systemOutCapture));
+    tng.run();
+    System.setOut(previousOut);
+
+    Assert.assertTrue(systemOutCapture.toString().contains("PASSED: testMethod(null)"));
   }
 }


### PR DESCRIPTION
Fixes NPE.

In case the test is created with a data provider providing null as a parameter, the TextReporter#logResults method will fail with NPE. 
This Report is run by the surefire plugin out of the box. 

`java.lang.NullPointerException
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:545)
	at java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:438)
	at org.testng.internal.Utils.extractParameterTypes(Utils.java:612)
	at org.testng.reporters.TextReporter.logResult(TextReporter.java:140)
	at org.testng.reporters.TextReporter.logResults(TextReporter.java:74)
	at org.testng.reporters.TextReporter.onFinish(TextReporter.java:34)
	at org.testng.TestRunner.fireEvent(TestRunner.java:923)`
