### PR TITLE
assertNotEquals returns fast when argument is null, not calling equals(Object) #2490

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -152,13 +152,10 @@ public class Assert {
     if ((expected == null) && (actual == null)) {
       return false;
     }
-    if (expected == null ^ actual == null) {
-      return true;
+    if (expected != null && expected.equals(actual)) {
+      return false;
     }
-    if (!expected.equals(actual) && !actual.equals(expected)) {
-      return true;
-    }
-    return false;
+    return true;
   }
 
   private static boolean areEqualImpl(Object actual, Object expected) {

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -152,10 +152,10 @@ public class Assert {
     if ((expected == null) && (actual == null)) {
       return false;
     }
-    if (expected != null && expected.equals(actual)) {
+    if (expected != null && actual != null && actual.equals(expected) && expected.equals(actual)) {
       return false;
     }
-    return true;
+      return true;
   }
 
   private static boolean areEqualImpl(Object actual, Object expected) {


### PR DESCRIPTION
Fixes # .https://github.com/cbeust/testng/issues/2490 : Assertions.assertNotEquals not working when actual is null and equals overriden