### PR TITLE
Add default Guice injection module with ITestContext and CurrentTestClass

### DIFF
--- a/core/src/main/java/org/testng/IModuleFactory.java
+++ b/core/src/main/java/org/testng/IModuleFactory.java
@@ -5,7 +5,9 @@ import com.google.inject.Module;
 /**
  * This interface is used by the moduleFactory attribute of the @Guice annotation. It allows users
  * to use different Guice modules based on the test class waiting to be injected.
+ * @deprecated inject {@code ITestContext} and {@code @CurrentTestClass Class<?>} instead.
  */
+@Deprecated
 public interface IModuleFactory {
 
   /**

--- a/core/src/main/java/org/testng/annotations/CurrentTestClass.java
+++ b/core/src/main/java/org/testng/annotations/CurrentTestClass.java
@@ -1,0 +1,19 @@
+package org.testng.annotations;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to inject the {@code Class} of the current test via Guice injector.
+ * Note: Guice does not support polymorphic lookup, so the injected type should be either
+ * {@code Class} or {@code Class<?>}.
+ */
+@Qualifier
+@Documented
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+public @interface CurrentTestClass {
+}

--- a/core/src/main/java/org/testng/annotations/Guice.java
+++ b/core/src/main/java/org/testng/annotations/Guice.java
@@ -20,5 +20,9 @@ public @interface Guice {
   /** @return the list of modules to query when trying to create an instance of this test class. */
   Class<? extends Module>[] modules() default {};
 
+  /**
+   * @deprecated use {@code @Inject ITestContext} and {@code @Inject @CurrentTestClass Class<?>} instead
+   */
+  @Deprecated
   Class<? extends IModuleFactory> moduleFactory() default IModuleFactory.class;
 }

--- a/core/src/main/java/org/testng/internal/objects/GuiceHelper.java
+++ b/core/src/main/java/org/testng/internal/objects/GuiceHelper.java
@@ -180,6 +180,7 @@ class GuiceHelper {
 
   private List<Module> getModules(Guice guice, Injector parentInjector, Class<?> testClass) {
     List<Module> result = Lists.newArrayList();
+    result.add(new TestContextModule(context, testClass));
     for (Class<? extends Module> moduleClass : guice.modules()) {
       List<Module> modules = getGuiceModules(moduleClass);
       if (modules != null && !modules.isEmpty()) {

--- a/core/src/main/java/org/testng/internal/objects/TestContextModule.java
+++ b/core/src/main/java/org/testng/internal/objects/TestContextModule.java
@@ -1,0 +1,33 @@
+package org.testng.internal.objects;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import org.testng.ITestContext;
+import org.testng.annotations.CurrentTestClass;
+
+/**
+ * Provides default Guice bindings so test code could inject {@link ITestContext}
+ * and {@code testCLass} if needed.
+ */
+public class TestContextModule extends AbstractModule {
+    private final ITestContext context;
+    private final Class<?> testClass;
+
+    public TestContextModule(ITestContext context, Class<?> testClass) {
+        this.context = context;
+        this.testClass = testClass;
+    }
+
+    @Override
+    protected void configure() {
+        // Guice does not allow null bindings, and sometimes context is null
+        // For instance, test.guice.issue279.IssueTest.classWithModuleDefinedInSuite
+        if (context != null) {
+            bind(ITestContext.class).toInstance(context);
+        }
+        bind(Class.class).annotatedWith(CurrentTestClass.class).toInstance(testClass);
+        bind(new TypeLiteral<Class<?>>() {
+        })
+                .annotatedWith(CurrentTestClass.class).toInstance(testClass);
+    }
+}

--- a/core/src/test/java/org/testng/internal/objects/GuiceHelperTest.java
+++ b/core/src/test/java/org/testng/internal/objects/GuiceHelperTest.java
@@ -1,9 +1,8 @@
 package org.testng.internal.objects;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertNotNull;
 
-import org.testng.Assert;
 import org.testng.IInjectorFactory;
 import org.testng.ITest;
 import org.testng.ITestObjectFactory;
@@ -30,9 +29,9 @@ public final class GuiceHelperTest {
 
         assertNotNull(injector);
         Module[] modules = injector.getModules();
-        assertNotNull(modules);
-        assertEquals(modules.length, 1);
-        Assert.assertEquals(modules[0], new SampleIModule().getModule());
+        assertThat(modules)
+                .describedAs("injector.getModules() should include new SampleIModule().getModule()")
+                .contains(new SampleIModule().getModule());
     }
 
     private static final class MockInjectorFactory implements IInjectorFactory {

--- a/core/src/test/java/test/dataprovider/StaticDataProviderSampleSample.java
+++ b/core/src/test/java/test/dataprovider/StaticDataProviderSampleSample.java
@@ -3,23 +3,34 @@ package test.dataprovider;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 
+import org.testng.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 @Guice(modules = StaticDataProviderSampleSample.InjectionProviderModule.class)
 public class StaticDataProviderSampleSample {
 
   @Test(dataProvider = "static", dataProviderClass = StaticProvider.class)
-  public void verifyStatic(String s) {}
+  public void verifyStatic(String s) {
+    assertEquals(s, "Cedric");
+  }
 
   @Test(dataProvider = "external", dataProviderClass = NonStaticProvider.class)
-  public void verifyExternal(String s) {}
+  public void verifyExternal(String s) {
+    assertEquals(s, "Cedric");
+  }
 
   @Test(dataProvider = "injection", dataProviderClass = FieldInjectionProvider.class)
-  public void verifyFieldInjection(String s) {}
+  public void verifyFieldInjection(String s) {
+    assertEquals(s, "Cedric");
+  }
 
   @Test(dataProvider = "injection", dataProviderClass = ConstructorInjectionProvider.class)
-  public void verifyConstructorInjection(String s) {}
+  public void verifyConstructorInjection(String s) {
+    assertEquals(s, "Cedric");
+  }
 
   public static class InjectionProviderModule extends AbstractModule {
 

--- a/core/src/test/java/test/guice/GuiceParentModule.java
+++ b/core/src/test/java/test/guice/GuiceParentModule.java
@@ -16,6 +16,5 @@ public class GuiceParentModule extends AbstractModule {
   protected void configure() {
     bind(MyService.class).toProvider(MyServiceProvider.class);
     bind(MyContext.class).to(MyContextImpl.class).in(Singleton.class);
-    bind(ITestContext.class).toInstance(context);
   }
 }

--- a/core/src/test/java/test/guice/GuiceTest.java
+++ b/core/src/test/java/test/guice/GuiceTest.java
@@ -29,7 +29,10 @@ public class GuiceTest extends SimpleBaseTest {
 
     assertThat(Guice1Test.m_object).isNotNull();
     assertThat(Guice2Test.m_object).isNotNull();
-    assertThat(Guice1Test.m_object).isEqualTo(Guice2Test.m_object);
+    assertThat(Guice1Test.m_object)
+            .describedAs("Guice injectors are generated for each test class, so different class " +
+                    "receive different ISingleton instances")
+            .isNotEqualTo(Guice2Test.m_object);
   }
 
   @Test

--- a/core/src/test/java/test/inject/InjectTestContextWithGuiceTest.java
+++ b/core/src/test/java/test/inject/InjectTestContextWithGuiceTest.java
@@ -1,0 +1,39 @@
+package test.inject;
+
+import org.testng.Assert;
+import org.testng.ITestContext;
+import org.testng.annotations.CurrentTestClass;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+@Guice
+public class InjectTestContextWithGuiceTest {
+    @Inject
+    public ITestContext testContext;
+
+    @Inject
+    @CurrentTestClass
+    public Class<?> currentClass;
+
+    @Inject
+    @CurrentTestClass
+    @SuppressWarnings("rawtypes")
+    public Class currentClassRaw;
+
+    @Test
+    public void verifyTestContext() {
+        Assert.assertNotNull(testContext, "testContext");
+    }
+
+    @Test
+    public void verifyGenericTestClass() {
+        Assert.assertNotNull(currentClass, "currentClass");
+    }
+
+    @Test
+    public void verifyRawTestClass() {
+        Assert.assertNotNull(currentClassRaw, "currentClassRaw");
+    }
+}

--- a/core/src/test/resources/testng.xml
+++ b/core/src/test/resources/testng.xml
@@ -262,6 +262,7 @@
       <class name="test.inject.InjectBeforeMethodTest"/>
       <class name="test.inject.InjectTestResultTest" />
       <class name="test.inject.InjectDataProviderTest"/>
+      <class name="test.inject.InjectTestContextWithGuiceTest"/>
       <class name="test.inject.NoInjectionTest" />
       <class name="test.inject.NativeInjectionTest" />
       <class name="test.inject.Github1298Test"/>


### PR DESCRIPTION
This adds a common Guice binding for `ITestContext` and `@CurrentTestClass Class<?>`.

I believe the feature renders `IModuleFactory` (Guice-specific factory) deprecated, and it makes it easier to implement custom test logic.

Note: I have not updated the changelog and documentation. I can do that if you think the feature is valuable.

Note: currently I bind `ITestContext`, so if the users had their own `ITestContext` binding, they would have to remove it. I guess the migration would be trivial: just remove `IModuleFactory` all over the place and that is it.

WDYT?

### Did you remember to?

- [x] Add test case(s)
- [ ] Update `CHANGES.txt`


