### PR TITLE
[GITHUB-2135] @BeforeClass and @AfterClass in superclass ignore group…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2135  @BeforeClass and @AfterClass in superclass ignore groups when running parallel in classes.
 Fixed: GITHUB-2653: Assert methods requires casting since TestNg 7.0 for mixed boxed and unboxed primitives in assertEquals.
 Fixed: GITHUB-2563: Skip test if its data provider provides no data (Krishnan Mahadevan)
 Fixed: GITHUB-2535: TestResult.getEndMillis() returns 0 for skipped configuration - after upgrading testng to 7.0 + (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -14,6 +14,7 @@ public final class RuntimeBehavior {
   private static final String MEMORY_FRIENDLY_MODE = "testng.memory.friendly";
   public static final String STRICTLY_HONOUR_PARALLEL_MODE = "testng.strict.parallel";
   public static final String TESTNG_DEFAULT_VERBOSE = "testng.default.verbose";
+  public static final String TESTNG_DISABLE_NEW_GROUP_BEHAVIOR = "testng.disable.new.group.beavhor";
 
   private RuntimeBehavior() {}
 
@@ -126,5 +127,15 @@ public final class RuntimeBehavior {
    */
   public static int getDefaultVerboseLevel() {
     return Integer.getInteger(TESTNG_DEFAULT_VERBOSE, 1);
+  }
+
+  /**
+   * Property to disable new behavior for groups. In Pull request #2167 Before/AfterGroups will no
+   * longer run if they are not added i the group filter in the suite.
+   *
+   * @return true if new group behavior is disabled.
+   */
+  public static boolean isNewGroupBehaviorDisabled() {
+    return Boolean.parseBoolean(System.getProperty(TESTNG_DISABLE_NEW_GROUP_BEHAVIOR, "false"));
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -4,6 +4,7 @@ import java.util.*;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
+import org.testng.internal.RuntimeBehavior;
 
 /** This class describes the tag &lt;test&gt; in testng.xml. */
 public class XmlTest implements Cloneable {
@@ -115,6 +116,9 @@ public class XmlTest implements Cloneable {
   }
 
   public boolean isGroupFilteringDisabled() {
+    if (RuntimeBehavior.isNewGroupBehaviorDisabled()) {
+      return false;
+    }
     return getIncludedGroups().isEmpty() && getExcludedGroups().isEmpty();
   }
 

--- a/testng-core/src/test/java/test/beforegroups/OrginalBehaviorTest.java
+++ b/testng-core/src/test/java/test/beforegroups/OrginalBehaviorTest.java
@@ -1,0 +1,94 @@
+package test.beforegroups;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+/** This Class is used for live demo sessions. Do not add any test code here. */
+public class OrginalBehaviorTest {
+
+  boolean valueA = false;
+  boolean valueB = false;
+
+  @BeforeClass
+  public void setup() {
+    System.setProperty("testng.disable.new.group.beavhor", "true");
+  }
+
+  @BeforeGroups(groups = "groupA")
+  public void beforeGroupA() {
+    System.out.println("beforeGroupA");
+    valueA = true;
+  }
+
+  @BeforeGroups(groups = "groupB")
+  public void beforeGroupB() {
+    valueB = true;
+    System.out.println("beforeGroupB");
+  }
+
+  @BeforeGroups(groups = "groupC")
+  public void beforeGroupC() {
+    System.out.println("beforeGroupC No Test exist, should not run.");
+  }
+
+  @Test
+  public void testA() {
+    System.out.println("TestA");
+  }
+
+  @Test
+  public void testB() {
+    System.out.println("TestB");
+  }
+
+  @Test
+  public void testC() {
+    System.out.println("TestC");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA1() {
+    System.out.println("testGroupA1");
+    Assert.assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA2() {
+    System.out.println("testGroupA2");
+    Assert.assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA3() {
+    System.out.println("testGroupA3");
+    Assert.assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupB")
+  public void testGroupB() {
+    System.out.println("testGroupB");
+    Assert.assertTrue(valueB, "BeforeGroupB was not executed");
+  }
+
+  @AfterGroups(groups = "groupA")
+  public void afterGroupA() {
+    System.out.println("afterGroupA");
+    valueA = false;
+  }
+
+  @AfterGroups(groups = "groupB")
+  public void afterGroupB() {
+    System.out.println("afterGroupB");
+    valueB = false;
+  }
+
+  @AfterClass
+  public void afterClass() {
+    Assert.assertFalse(valueA, "AfterGroupsA was not executed");
+    Assert.assertFalse(valueB, "AfterGroupsB was not executed");
+  }
+}


### PR DESCRIPTION
### Did you remember to?

- [x ] Add test case(s)
- [ x] Update `CHANGES.txt`

We encourage pull requests that:

*Enable old behavior for Before/AfterGroups 
