### PR TITLE
Restore Ordering for DependsOnGroups by using separate Priority on Configuration Methods alternative 2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 Current
 Fixed: GITHUB-2643: assertEquals(Set,Set) now ignores ordering as it did before. (Elis Edlund)
 Fixed: GITHUB-2653: Assert methods requires casting since TestNg 7.0 for mixed boxed and unboxed primitives in assertEquals.
+New:   GITHUB-2663 Add support for Priority in Configuration Methods. (Martin Aldrin)
+Fixed: GITHUB-2653: Assert methods requires casting since TestNg 7.0 for mixed boxed and unboxed primitives in assertEquals. (Martin Aldrin)
 Fixed: GITHUB-2229: Restore @BeforeGroups and @AfterGroups Annotations functionality (Krishnan Mahadevan)
 Fixed: GITHUB-2563: Skip test if its data provider provides no data (Krishnan Mahadevan)
 Fixed: GITHUB-2535: TestResult.getEndMillis() returns 0 for skipped configuration - after upgrading testng to 7.0 + (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/ITestNGMethod.java
+++ b/testng-core-api/src/main/java/org/testng/ITestNGMethod.java
@@ -220,6 +220,10 @@ public interface ITestNGMethod extends Cloneable {
 
   void setInterceptedPriority(int priority);
 
+  int getClassHierarchyPriority();
+
+  void setClassHierarchyPriority(int priority);
+
   /** @return the XmlTest this method belongs to. */
   XmlTest getXmlTest();
 

--- a/testng-core-api/src/main/java/org/testng/annotations/AfterClass.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/AfterClass.java
@@ -77,4 +77,11 @@ public @interface AfterClass {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/AfterGroups.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/AfterGroups.java
@@ -87,4 +87,11 @@ public @interface AfterGroups {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/AfterMethod.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/AfterMethod.java
@@ -99,4 +99,11 @@ public @interface AfterMethod {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/AfterSuite.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/AfterSuite.java
@@ -77,4 +77,11 @@ public @interface AfterSuite {
    * @return the valude (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/AfterTest.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/AfterTest.java
@@ -77,4 +77,11 @@ public @interface AfterTest {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/BeforeClass.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/BeforeClass.java
@@ -77,4 +77,11 @@ public @interface BeforeClass {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/BeforeGroups.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/BeforeGroups.java
@@ -87,4 +87,11 @@ public @interface BeforeGroups {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/BeforeMethod.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/BeforeMethod.java
@@ -99,4 +99,11 @@ public @interface BeforeMethod {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/BeforeSuite.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/BeforeSuite.java
@@ -77,4 +77,11 @@ public @interface BeforeSuite {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/BeforeTest.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/BeforeTest.java
@@ -77,4 +77,11 @@ public @interface BeforeTest {
    * @return the value (default 0)
    */
   long timeOut() default 0;
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int priority() default 0;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/ITestOrConfiguration.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/ITestOrConfiguration.java
@@ -40,4 +40,11 @@ public interface ITestOrConfiguration extends IParameterizable {
   String getDescription();
 
   void setDescription(String description);
+
+  /**
+   * The scheduling priority. Lower priorities will be scheduled first.
+   *
+   * @return the value (default 0)
+   */
+  int getPriority();
 }

--- a/testng-core-api/src/main/java/org/testng/internal/Systematiser.java
+++ b/testng-core-api/src/main/java/org/testng/internal/Systematiser.java
@@ -10,6 +10,7 @@ public final class Systematiser {
 
   private static final Comparator<ITestNGMethod> COMPARE_INSTANCES =
       Comparator.comparingInt(ITestNGMethod::getPriority)
+          .thenComparing(ITestNGMethod::getClassHierarchyPriority)
           .thenComparing(method -> method.getRealClass().getName())
           .thenComparing(ITestNGMethod::getMethodName)
           .thenComparing(Object::toString)

--- a/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -74,6 +74,7 @@ public abstract class BaseTestMethod implements ITestNGMethod, IInvocationStatus
   private boolean m_ignoreMissingDependencies;
   private int m_priority;
   private int m_interceptedPriority;
+  private int m_classHierarchyPriority;
 
   private XmlTest m_xmlTest;
   private final Object m_instance;
@@ -708,6 +709,16 @@ public abstract class BaseTestMethod implements ITestNGMethod, IInvocationStatus
   @Override
   public void setInterceptedPriority(int priority) {
     m_interceptedPriority = priority;
+  }
+
+  @Override
+  public int getClassHierarchyPriority() {
+    return m_classHierarchyPriority;
+  }
+
+  @Override
+  public void setClassHierarchyPriority(int priority) {
+    m_classHierarchyPriority = priority;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/ClonedMethod.java
@@ -327,7 +327,7 @@ public class ClonedMethod implements ITestNGMethod {
 
   @Override
   public void setPriority(int priority) {
-    // ignored
+    m_method.setPriority(priority);
   }
 
   @Override
@@ -337,7 +337,17 @@ public class ClonedMethod implements ITestNGMethod {
 
   @Override
   public void setInterceptedPriority(int priority) {
-    // ignored
+    m_method.setInterceptedPriority(priority);
+  }
+
+  @Override
+  public int getClassHierarchyPriority() {
+    return m_method.getClassHierarchyPriority();
+  }
+
+  @Override
+  public void setClassHierarchyPriority(int priority) {
+    m_method.setClassHierarchyPriority(priority);
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/ConfigurationMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/ConfigurationMethod.java
@@ -409,6 +409,7 @@ public class ConfigurationMethod extends BaseTestMethod {
       m_inheritGroupsFromTestClass = annotation.getInheritGroups();
       setEnabled(annotation.getEnabled());
       setDescription(annotation.getDescription());
+      setPriority(annotation.getPriority());
     }
 
     if (annotation != null && annotation.isFakeConfiguration()) {
@@ -503,6 +504,7 @@ public class ConfigurationMethod extends BaseTestMethod {
     clone.setDescription(getDescription());
     clone.setEnabled(getEnabled());
     clone.setParameterInvocationCount(getParameterInvocationCount());
+    clone.setPriority(getPriority());
     clone.m_inheritGroupsFromTestClass = inheritGroupsFromTestClass();
 
     return clone;

--- a/testng-core/src/main/java/org/testng/internal/MethodHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/MethodHelper.java
@@ -27,7 +27,6 @@ import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.collections.Pair;
 import org.testng.internal.invokers.IInvocationStatus;
 import org.testng.util.TimeUtils;
-import org.testng.xml.XmlTest;
 
 /** Collection of helper methods to help sort and arrange methods. */
 public class MethodHelper {
@@ -259,11 +258,7 @@ public class MethodHelper {
 
     Map<Object, List<ITestNGMethod>> testInstances = sortMethodsByInstance(methods);
 
-    XmlTest xmlTest = null;
     for (ITestNGMethod m : methods) {
-      if (xmlTest == null) {
-        xmlTest = m.getXmlTest();
-      }
       result.addNode(m);
 
       List<ITestNGMethod> predecessors = Lists.newArrayList();
@@ -289,14 +284,13 @@ public class MethodHelper {
         }
         predecessors.addAll(Arrays.asList(methodsNamed));
       }
-      if (XmlTest.isGroupBasedExecution(xmlTest)) {
-        String[] groupsDependedUpon = m.getGroupsDependedUpon();
-        if (groupsDependedUpon.length > 0) {
-          for (String group : groupsDependedUpon) {
-            ITestNGMethod[] methodsThatBelongToGroup =
-                MethodGroupsHelper.findMethodsThatBelongToGroup(m, methods, group);
-            predecessors.addAll(Arrays.asList(methodsThatBelongToGroup));
-          }
+      // Should not be part of this commit. just added until GITHUB-2664 is solved.
+      String[] groupsDependedUpon = m.getGroupsDependedUpon();
+      if (groupsDependedUpon.length > 0) {
+        for (String group : groupsDependedUpon) {
+          ITestNGMethod[] methodsThatBelongToGroup =
+              MethodGroupsHelper.findMethodsThatBelongToGroup(m, methods, group);
+          predecessors.addAll(Arrays.asList(methodsThatBelongToGroup));
         }
       }
 

--- a/testng-core/src/main/java/org/testng/internal/MethodInheritance.java
+++ b/testng-core/src/main/java/org/testng/internal/MethodInheritance.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
-import org.testng.xml.XmlTest;
 
 public class MethodInheritance {
 
@@ -135,14 +134,11 @@ public class MethodInheritance {
                 ITestNGMethod m1 = l.get(i);
                 for (int j = i + 1; j < l.size(); j++) {
                   ITestNGMethod m2 = l.get(j);
-                  boolean groupMode = XmlTest.isGroupBasedExecution(m2.getXmlTest());
-                  if (groupMode) {
-                    // Do not resort to adding implicit depends-on if there are groups
-                    continue;
-                  }
                   if (!equalsEffectiveClass(m1, m2) && !dependencyExists(m1, m2, methods)) {
                     Utils.log("MethodInheritance", 4, m2 + " DEPENDS ON " + m1);
-                    m2.addMethodDependedUpon(MethodHelper.calculateMethodCanonicalName(m1));
+                    if (m1.getClassHierarchyPriority() >= m2.getClassHierarchyPriority()) {
+                      m2.setClassHierarchyPriority(m2.getClassHierarchyPriority() + 1);
+                    }
                   }
                 }
               }

--- a/testng-core/src/main/java/org/testng/internal/TestMethodComparator.java
+++ b/testng-core/src/main/java/org/testng/internal/TestMethodComparator.java
@@ -16,6 +16,12 @@ public class TestMethodComparator implements Comparator<ITestNGMethod> {
       return prePriDiff;
     }
 
+    int prePriDiff2 =
+        Integer.compare(o1.getClassHierarchyPriority(), o2.getClassHierarchyPriority());
+    if (prePriDiff2 != 0) {
+      return prePriDiff2;
+    }
+
     int priDiff = Integer.compare(o1.getPriority(), o2.getPriority());
     if (priDiff != 0) {
       return priDiff;

--- a/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
@@ -345,6 +345,16 @@ public class WrappedTestNGMethod implements ITestNGMethod {
   }
 
   @Override
+  public int getClassHierarchyPriority() {
+    return testNGMethod.getClassHierarchyPriority();
+  }
+
+  @Override
+  public void setClassHierarchyPriority(int priority) {
+    testNGMethod.setClassHierarchyPriority(priority);
+  }
+
+  @Override
   public XmlTest getXmlTest() {
     return testNGMethod.getXmlTest();
   }

--- a/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -197,6 +197,7 @@ public class AnnotationHelper {
     result.setGroups(bs.getGroups());
     result.setInheritGroups(bs.getInheritGroups());
     result.setTimeOut(bs.getTimeOut());
+    result.setPriority(bs.getPriority());
   }
 
   public static List<Class<? extends IAnnotation>> getAllAnnotations() {

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -109,6 +109,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IAfterSuite.class) {
       AfterSuite bs = (AfterSuite) a;
@@ -136,6 +137,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IBeforeTest.class) {
       BeforeTest bs = (BeforeTest) a;
@@ -163,6 +165,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IAfterTest.class) {
       AfterTest bs = (AfterTest) a;
@@ -190,6 +193,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IBeforeGroups.class) {
       BeforeGroups bs = (BeforeGroups) a;
@@ -218,6 +222,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IAfterGroups.class) {
       AfterGroups bs = (AfterGroups) a;
@@ -246,6 +251,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IBeforeClass.class) {
       BeforeClass bs = (BeforeClass) a;
@@ -273,6 +279,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IAfterClass.class) {
       AfterClass bs = (AfterClass) a;
@@ -300,6 +307,7 @@ public class JDK15TagFactory {
               false,
               false,
               bs.timeOut(),
+              bs.priority(),
               new String[0]);
     } else if (annotationClass == IBeforeMethod.class) {
       BeforeMethod bs = (BeforeMethod) a;
@@ -327,6 +335,7 @@ public class JDK15TagFactory {
               bs.firstTimeOnly(),
               false,
               bs.timeOut(),
+              bs.priority(),
               bs.onlyForGroups());
     } else if (annotationClass == IAfterMethod.class) {
       AfterMethod bs = (AfterMethod) a;
@@ -354,6 +363,7 @@ public class JDK15TagFactory {
               false,
               bs.lastTimeOnly(),
               bs.timeOut(),
+              bs.priority(),
               bs.onlyForGroups());
     }
 
@@ -383,6 +393,7 @@ public class JDK15TagFactory {
       boolean firstTimeOnly,
       boolean lastTimeOnly,
       long timeOut,
+      int priority,
       String[] groupFilters) {
     ConfigurationAnnotation result = new ConfigurationAnnotation();
     result.setIsBeforeGroups(isBeforeGroups);
@@ -410,6 +421,7 @@ public class JDK15TagFactory {
     result.setFirstTimeOnly(firstTimeOnly);
     result.setLastTimeOnly(lastTimeOnly);
     result.setTimeOut(timeOut);
+    result.setPriority(priority);
 
     return result;
   }

--- a/testng-core/src/main/java/org/testng/internal/annotations/TestOrConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/TestOrConfiguration.java
@@ -62,6 +62,7 @@ public class TestOrConfiguration extends BaseAnnotation implements ITestOrConfig
     m_description = description;
   }
 
+  @Override
   public int getPriority() {
     return m_priority;
   }

--- a/testng-core/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/testng-core/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -523,6 +523,14 @@ public class MethodInstanceTest {
     public void setInterceptedPriority(int priority) {}
 
     @Override
+    public int getClassHierarchyPriority() {
+      return 0;
+    }
+
+    @Override
+    public void setClassHierarchyPriority(int priority) {}
+
+    @Override
     public XmlTest getXmlTest() {
       return null;
     }

--- a/testng-core/src/test/java/org/testng/internal/paramhandler/FakeTestNGMethod.java
+++ b/testng-core/src/test/java/org/testng/internal/paramhandler/FakeTestNGMethod.java
@@ -322,6 +322,14 @@ public class FakeTestNGMethod implements ITestNGMethod {
   public void setInterceptedPriority(int priority) {}
 
   @Override
+  public int getClassHierarchyPriority() {
+    return 0;
+  }
+
+  @Override
+  public void setClassHierarchyPriority(int priority) {}
+
+  @Override
   public XmlTest getXmlTest() {
     return null;
   }

--- a/testng-core/src/test/java/test/ConfigurationMethodPriorityTest.java
+++ b/testng-core/src/test/java/test/ConfigurationMethodPriorityTest.java
@@ -1,0 +1,89 @@
+package test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.configuration.issue2663.ConfiguratinMethodPriorityMultiLevelInheritanceSampleTest;
+import test.configuration.issue2663.ConfigurationMethodPrioritySampleTest;
+import test.configuration.issue2663.ConfigurationMethodPriorityWithGroupDependencySampleTest;
+import test.configuration.issue2663.ConfigurationMethodPriorityWithMethodDependencySampleTest;
+
+public class ConfigurationMethodPriorityTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-2663")
+  public void ensureThatPriorityWorksOnConfigurationMethods() {
+    TestNG testng = create(ConfigurationMethodPrioritySampleTest.class);
+    testng.run();
+    assertThat(testng.getStatus()).isEqualTo(0);
+    List<String> expectedLogs =
+        Arrays.asList(
+            "beforeSuiteB",
+            "beforeSuiteA",
+            "beforeClassB",
+            "beforeClassA",
+            "beforeMethodB",
+            "beforeMethodA",
+            "TestB",
+            "afterMethodB",
+            "afterMethodA",
+            "beforeMethodB",
+            "beforeMethodA",
+            "TestA",
+            "afterMethodB",
+            "afterMethodA",
+            "afterClassB",
+            "afterClassA",
+            "afterSuiteB",
+            "afterSuiteA");
+    assertThat(ConfigurationMethodPrioritySampleTest.logs).containsExactlyElementsOf(expectedLogs);
+  }
+
+  @Test(description = "GITHUB-2663")
+  public void ensureThatPriorityWorksOnConfigurationMethodsWithGroupDependency() {
+    List<String> expectedOrder1 =
+        Arrays.asList(
+            "s3", "s2", "s1", "t3", "t2", "t1", "c3", "c2", "c1", "m3", "m2", "m1", "test3", "m3",
+            "m2", "m1", "test2", "m3", "m2", "m1", "test1");
+    TestNG tng = create(ConfigurationMethodPriorityWithGroupDependencySampleTest.class);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    tng.addListener(listener);
+    tng.run();
+    System.out.println(expectedOrder1);
+    System.out.println(listener.getSucceedMethodNames());
+    Assert.assertEquals(listener.getSucceedMethodNames(), expectedOrder1);
+  }
+
+  @Test(description = "GITHUB-2663")
+  public void ensureThatPriorityWorksOnConfigurationMethodsWithMethodDependency() {
+    List<String> expectedOrder1 =
+        Arrays.asList(
+            "s3", "s2", "s1", "t3", "t2", "t1", "c3", "c2", "c1", "m3", "m2", "m1", "test3", "m3",
+            "m2", "m1", "test2", "m3", "m2", "m1", "test1");
+    TestNG tng = create(ConfigurationMethodPriorityWithMethodDependencySampleTest.class);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    tng.addListener(listener);
+    tng.run();
+    System.out.println(expectedOrder1);
+    System.out.println(listener.getSucceedMethodNames());
+    Assert.assertEquals(listener.getSucceedMethodNames(), expectedOrder1);
+  }
+
+  @Test(description = "GITHUB-2663")
+  public void ensureThatPriorityWorksOnConfigurationMethodsMultiLevelInheritanc() {
+    List<String> expectedOrder1 =
+        Arrays.asList(
+            "s3", "s2", "s1", "t3", "t2", "t1", "c3", "c2", "c1", "m3", "m2", "m1", "test3", "m3",
+            "m2", "m1", "test2", "m3", "m2", "m1", "test1");
+    TestNG tng = create(ConfiguratinMethodPriorityMultiLevelInheritanceSampleTest.class);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    tng.addListener(listener);
+    tng.run();
+    System.out.println(expectedOrder1);
+    System.out.println(listener.getSucceedMethodNames());
+    Assert.assertEquals(listener.getSucceedMethodNames(), expectedOrder1);
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2432/IssueTest.java
+++ b/testng-core/src/test/java/test/configuration/issue2432/IssueTest.java
@@ -34,9 +34,10 @@ public class IssueTest extends SimpleBaseTest {
     List<String> expected =
         Arrays.asList(
             "prepareConfig",
+            "prepareConfigForTest1",
             "uploadConfigToDatabase",
             "verifyConfigurationAfterInstall",
-            "prepareConfigForTest1",
+            "prepareConfigForTest2",
             "test1");
     assertThat(listener.getInvokedMethodNames()).containsExactlyElementsOf(expected);
   }

--- a/testng-core/src/test/java/test/configuration/issue2432/Test1.java
+++ b/testng-core/src/test/java/test/configuration/issue2432/Test1.java
@@ -7,6 +7,9 @@ public class Test1 extends Base {
   @BeforeSuite(groups = "prepareConfig")
   public void prepareConfigForTest1() {}
 
+  @BeforeSuite(groups = "prepareConfig2")
+  public void prepareConfigForTest2() {}
+
   @Test(groups = "test")
   public void test1() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityBaseClass1.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityBaseClass1.java
@@ -1,0 +1,42 @@
+package test.configuration.issue2663;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ConfiguratinMethodPriorityBaseClass1 {
+  @BeforeSuite(
+      groups = {"g1"},
+      priority = 2)
+  public void s3() {
+    System.out.println("s1");
+  }
+
+  @BeforeClass(
+      groups = {"g1"},
+      priority = 2)
+  public void c3() {
+    System.out.println("c1");
+  }
+
+  @BeforeTest(
+      groups = {"g1"},
+      priority = 2)
+  public void t3() {
+    System.out.println("t1");
+  }
+
+  @BeforeMethod(
+      groups = {"g1"},
+      priority = 2)
+  public void m3() {
+    System.out.println("m1");
+  }
+
+  @Test(groups = {"g1"})
+  public void test3() {
+    System.out.println("test1");
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityBaseClass2.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityBaseClass2.java
@@ -1,0 +1,82 @@
+package test.configuration.issue2663;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ConfiguratinMethodPriorityBaseClass2 extends ConfiguratinMethodPriorityBaseClass1 {
+
+  @BeforeSuite(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void s2() {
+    System.out.println("s2");
+  }
+
+  @BeforeSuite(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void s1() {
+    System.out.println("s3");
+  }
+
+  @BeforeClass(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void c2() {
+    System.out.println("c2");
+  }
+
+  @BeforeClass(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void c1() {
+    System.out.println("c3");
+  }
+
+  @BeforeTest(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void t2() {
+    System.out.println("t2");
+  }
+
+  @BeforeTest(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void t1() {
+    System.out.println("t3");
+  }
+
+  @BeforeMethod(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void m2() {
+    System.out.println("m2");
+  }
+
+  @BeforeMethod(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void m1() {
+    System.out.println("m3");
+  }
+
+  @Test(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void test2() {
+    System.out.println("test2");
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityMultiLevelInheritanceSampleTest.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfiguratinMethodPriorityMultiLevelInheritanceSampleTest.java
@@ -1,0 +1,15 @@
+package test.configuration.issue2663;
+
+import org.testng.annotations.Test;
+
+public class ConfiguratinMethodPriorityMultiLevelInheritanceSampleTest
+    extends ConfiguratinMethodPriorityBaseClass2 {
+
+  @Test(
+      groups = {"g3"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void test1() {
+    System.out.println("test3");
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPrioritySampleTest.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPrioritySampleTest.java
@@ -1,0 +1,85 @@
+package test.configuration.issue2663;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+public class ConfigurationMethodPrioritySampleTest {
+  public static List<String> logs = new ArrayList<>();
+
+  @BeforeSuite(priority = 100)
+  public void beforeSuiteA() {
+    logs.add("beforeSuiteA");
+  }
+
+  @BeforeSuite(priority = 1)
+  public void beforeSuiteB() {
+    logs.add("beforeSuiteB");
+  }
+
+  @BeforeClass(priority = 100)
+  public void beforeClassA() {
+    logs.add("beforeClassA");
+  }
+
+  @BeforeClass(priority = 1)
+  public void beforeClassB() {
+    logs.add("beforeClassB");
+  }
+
+  @BeforeMethod(priority = 100)
+  public void beforeMethodA() {
+    logs.add("beforeMethodA");
+  }
+
+  @BeforeMethod(priority = 1)
+  public void beforeMethodB() {
+    logs.add("beforeMethodB");
+  }
+
+  @Test(priority = 100)
+  public void testA() {
+    logs.add("TestA");
+  }
+
+  @Test(priority = 0)
+  public void testB() {
+    logs.add("TestB");
+  }
+
+  @AfterSuite(priority = 100)
+  public void afterSuiteA() {
+    logs.add("afterSuiteA");
+  }
+
+  @AfterSuite(priority = 1)
+  public void afterSuiteB() {
+    logs.add("afterSuiteB");
+  }
+
+  @AfterClass(priority = 100)
+  public void afterClassA() {
+    logs.add("afterClassA");
+  }
+
+  @AfterClass(priority = 1)
+  public void afterClassB() {
+    logs.add("afterClassB");
+  }
+
+  @AfterMethod(priority = 100)
+  public void afterMethodA() {
+    logs.add("afterMethodA");
+  }
+
+  @AfterMethod(priority = 1)
+  public void afterMethodB() {
+    logs.add("afterMethodB");
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPriorityWithGroupDependencySampleTest.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPriorityWithGroupDependencySampleTest.java
@@ -1,0 +1,123 @@
+package test.configuration.issue2663;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ConfigurationMethodPriorityWithGroupDependencySampleTest {
+
+  @BeforeSuite(
+      groups = {"g1"},
+      priority = 2)
+  public void s3() {
+    System.out.println("s1");
+  }
+
+  @BeforeSuite(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void s2() {
+    System.out.println("s2");
+  }
+
+  @BeforeSuite(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void s1() {
+    System.out.println("s3");
+  }
+
+  @BeforeClass(
+      groups = {"g1"},
+      priority = 2)
+  public void c3() {
+    System.out.println("c1");
+  }
+
+  @BeforeClass(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void c2() {
+    System.out.println("c2");
+  }
+
+  @BeforeClass(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void c1() {
+    System.out.println("c3");
+  }
+
+  @BeforeTest(
+      groups = {"g1"},
+      priority = 2)
+  public void t3() {
+    System.out.println("t1");
+  }
+
+  @BeforeTest(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void t2() {
+    System.out.println("t2");
+  }
+
+  @BeforeTest(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void t1() {
+    System.out.println("t3");
+  }
+
+  @BeforeMethod(
+      groups = {"g1"},
+      priority = 2)
+  public void m3() {
+    System.out.println("m1");
+  }
+
+  @BeforeMethod(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void m2() {
+    System.out.println("m2");
+  }
+
+  @BeforeMethod(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void m1() {
+    System.out.println("m3");
+  }
+
+  @Test(groups = {"g1"})
+  public void test3() {
+    System.out.println("test1");
+  }
+
+  @Test(
+      groups = {"g2"},
+      dependsOnGroups = "g1",
+      priority = 0)
+  public void test2() {
+    System.out.println("test2");
+  }
+
+  @Test(
+      groups = {"g3"},
+      dependsOnGroups = "g1",
+      priority = 1)
+  public void test1() {
+    System.out.println("test3");
+  }
+}

--- a/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPriorityWithMethodDependencySampleTest.java
+++ b/testng-core/src/test/java/test/configuration/issue2663/ConfigurationMethodPriorityWithMethodDependencySampleTest.java
@@ -1,0 +1,85 @@
+package test.configuration.issue2663;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ConfigurationMethodPriorityWithMethodDependencySampleTest {
+
+  @BeforeSuite(priority = 2)
+  public void s3() {
+    System.out.println("s3");
+  }
+
+  @BeforeSuite(dependsOnMethods = "s3", priority = 0)
+  public void s2() {
+    System.out.println("s2");
+  }
+
+  @BeforeSuite(dependsOnMethods = "s3", priority = 1)
+  public void s1() {
+    System.out.println("s1");
+  }
+
+  @BeforeClass(priority = 2)
+  public void c3() {
+    System.out.println("c3");
+  }
+
+  @BeforeClass(dependsOnMethods = "c3", priority = 0)
+  public void c2() {
+    System.out.println("c2");
+  }
+
+  @BeforeClass(dependsOnMethods = "c3", priority = 1)
+  public void c1() {
+    System.out.println("c1");
+  }
+
+  @BeforeTest(priority = 2)
+  public void t3() {
+    System.out.println("t3");
+  }
+
+  @BeforeTest(dependsOnMethods = "t3", priority = 0)
+  public void t2() {
+    System.out.println("t2");
+  }
+
+  @BeforeTest(dependsOnMethods = "t3", priority = 1)
+  public void t1() {
+    System.out.println("t1");
+  }
+
+  @BeforeMethod(priority = 2)
+  public void m3() {
+    System.out.println("m3");
+  }
+
+  @BeforeMethod(dependsOnMethods = "m3", priority = 0)
+  public void m2() {
+    System.out.println("m2");
+  }
+
+  @BeforeMethod(dependsOnMethods = "m3", priority = 1)
+  public void m1() {
+    System.out.println("m1");
+  }
+
+  @Test(groups = {"g1"})
+  public void test3() {
+    System.out.println("test3");
+  }
+
+  @Test(dependsOnMethods = "test3", priority = 0)
+  public void test2() {
+    System.out.println("test2");
+  }
+
+  @Test(dependsOnMethods = "test3", priority = 1)
+  public void test1() {
+    System.out.println("test1");
+  }
+}

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -996,4 +996,11 @@
       <class name="org.testng.BasicTest"/>
     </classes>
   </test>
+  
+  <!-- <test name="GITHUB-2663">
+    <classes>
+      <class name="test.ConfigurationMethodPriorityTest"/>
+    </classes>
+  </test> -->
+  
 </suite>

--- a/testng-runner-api/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
+++ b/testng-runner-api/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
@@ -30,6 +30,7 @@ public class LiteWeightTestNGMethod implements ITestNGMethod {
   private final List<String> methodsDependedUpon = new LinkedList<>();
   private int priority;
   private int interceptedPriority;
+  private int classHierarchyPriority;
   private final XmlTest xmlTest;
   private final String qualifiedName;
   private final boolean isBeforeTestConfiguration;
@@ -83,6 +84,7 @@ public class LiteWeightTestNGMethod implements ITestNGMethod {
     }
     priority = iTestNGMethod.getPriority();
     interceptedPriority = iTestNGMethod.getInterceptedPriority();
+    classHierarchyPriority = iTestNGMethod.getClassHierarchyPriority();
     xmlTest = iTestNGMethod.getXmlTest();
     qualifiedName = iTestNGMethod.getQualifiedName();
     isBeforeTestConfiguration = iTestNGMethod.isBeforeTestConfiguration();
@@ -473,6 +475,16 @@ public class LiteWeightTestNGMethod implements ITestNGMethod {
   @Override
   public void setInterceptedPriority(int priority) {
     this.interceptedPriority = priority;
+  }
+
+  @Override
+  public int getClassHierarchyPriority() {
+    return interceptedPriority;
+  }
+
+  @Override
+  public void setClassHierarchyPriority(int priority) {
+    this.classHierarchyPriority = priority;
   }
 
   @Override


### PR DESCRIPTION
Add support for Priority in Configuration Methods and restore DependsOnGroups alternativ 2


Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
