### PR TITLE
JarFileUtils.delete(File f) throw actual exception (instead of FileNotFound) when file cannot be deleted #2825

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ z_build
 .DS_Store
 outputDir/
 **/Version.java
+**/bin/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2825: JarFileUtils.delete(File f) throw actual exception (instead of FileNotFound) when file cannot be deleted (Steven Jubb)
 Fixed: GITHUB2818: Add configuration key for callback discrepancy behavior (Krishnan Mahadevan)
 Fixed: GITHUB-2819: Ability to retry a data provider in case of failures (Krishnan Mahadevan)
 Fixed: GITHUB-2308: StringIndexOutOfBoundsException in findClassesInPackage - Surefire/Maven - JDK 11 fails (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/JarFileUtils.java
+++ b/testng-core/src/main/java/org/testng/JarFileUtils.java
@@ -1,7 +1,6 @@
 package org.testng;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -112,7 +111,11 @@ class JarFileUtils {
     if (f.isDirectory()) {
       for (File c : Objects.requireNonNull(f.listFiles())) delete(c);
     }
-    if (!f.delete()) throw new FileNotFoundException("Failed to delete file: " + f);
+
+    /** * Provide better logging for files temp that fail to be cleaned up. */
+    if (!Files.deleteIfExists(f.toPath())) {
+      Utils.log("TestNG", 2, "Failed to delete non-existent temp file: " + f.getPath());
+    }
   }
 
   private boolean matchesXmlPathInJar(JarEntry je) {

--- a/testng-core/src/main/java/org/testng/JarFileUtils.java
+++ b/testng-core/src/main/java/org/testng/JarFileUtils.java
@@ -111,11 +111,7 @@ class JarFileUtils {
     if (f.isDirectory()) {
       for (File c : Objects.requireNonNull(f.listFiles())) delete(c);
     }
-
-    /** * Provide better logging for files temp that fail to be cleaned up. */
-    if (!Files.deleteIfExists(f.toPath())) {
-      Utils.log("TestNG", 2, "Failed to delete non-existent temp file: " + f.getPath());
-    }
+    Files.deleteIfExists(f.toPath());
   }
 
   private boolean matchesXmlPathInJar(JarEntry je) {


### PR DESCRIPTION
Fixes #2825 .

Changed JarFileUtils.delete(File f) throw actual exception (instead of FileNotFound) when file cannot be deleted, as recommended by SonarSource (https://rules.sonarsource.com/java/tag/error-handling/RSPEC-4042).

If the file is not found, a log message is generated.
[Files.deleteIfExists() also throws:](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path))

> DirectoryNotEmptyException - if the file is a directory and could not otherwise be deleted because the directory is not empty (optional specific exception)

>IOException - if an I/O error occurs

>SecurityException  - In the case of the default provider, and a security manager is installed, the SecurityManager.checkDelete(String) method is invoked to check delete access to the file.

### Did you remember to?

- [ ] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`