### PR TITLE
Add addition yml extension

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Added .yml file extension for yaml suite files, previously only .yaml was allowed for yaml (Steven Jubb)
 Fixed: GITHUB-2770: FileAlreadyExistsException when report is generated (melloware)
 Fixed: GITHUB-2825: Programically Loading TestNG Suite from JAR File Fails to Delete Temporary Copy of Suite File (Steven Jubb)
 Fixed: GITHUB-2818: Add configuration key for callback discrepancy behavior (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/Converter.java
+++ b/testng-core/src/main/java/org/testng/Converter.java
@@ -65,7 +65,7 @@ public class Converter {
           if (file.endsWith(".xml")) {
             File newFile = new File(m_outputDirectory, baseName + ".yaml");
             writeFile(newFile, Yaml.toYaml(suite).toString());
-          } else if (file.endsWith(".yaml")) {
+          } else if (file.endsWith(".yaml") || file.endsWith(".yml")) {
             File newFile = new File(m_outputDirectory, baseName + ".xml");
             writeFile(newFile, suite.toXml());
           } else {

--- a/testng-core/src/main/java/org/testng/internal/YamlParser.java
+++ b/testng-core/src/main/java/org/testng/internal/YamlParser.java
@@ -21,6 +21,7 @@ public class YamlParser implements ISuiteParser {
 
   @Override
   public boolean accept(String fileName) {
-    return Parser.hasFileScheme(fileName) && fileName.endsWith(".yaml");
+    return Parser.hasFileScheme(fileName) && fileName.endsWith(".yaml")
+        || fileName.endsWith(".yml");
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/YamlParser.java
+++ b/testng-core/src/main/java/org/testng/internal/YamlParser.java
@@ -21,7 +21,7 @@ public class YamlParser implements ISuiteParser {
 
   @Override
   public boolean accept(String fileName) {
-    return Parser.hasFileScheme(fileName) && fileName.endsWith(".yaml")
-        || fileName.endsWith(".yml");
+    return Parser.hasFileScheme(fileName)
+        && (fileName.endsWith(".yaml") || fileName.endsWith(".yml"));
   }
 }

--- a/testng-core/src/test/java/test/yaml/YamlTest.java
+++ b/testng-core/src/test/java/test/yaml/YamlTest.java
@@ -1,6 +1,8 @@
 package test.yaml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,6 +31,17 @@ public class YamlTest extends SimpleBaseTest {
     return new Object[][] {
       new Object[] {"a1"}, new Object[] {"a2"}, new Object[] {"a3"}, new Object[] {"a4"},
     };
+  }
+
+  @Test(
+      description =
+          "Validate that the YamlParser accepts yaml files with a .yaml or a .yml file extension, but not other file types.")
+  public void accept() {
+    YamlParser yamlParser = new YamlParser();
+
+    assertTrue(yamlParser.accept("TestSuite.yml"));
+    assertTrue(yamlParser.accept("TestSuite.yaml"));
+    assertFalse(yamlParser.accept("TestSuite.xml"));
   }
 
   @Test(dataProvider = "dp")


### PR DESCRIPTION
New: Added .yml to list of accepted YAML file extensions for suite files. Previously, only .yaml was accepted.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`
