### PR TITLE
[ci] Update GitHub Actions to latest major/pinned release

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v5
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v2

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -13,6 +13,6 @@ jobs:
     if: github.repository_owner == 'testng-team'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Label Commenter
         uses: peaceiris/actions-label-commenter@v1

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Gradle wrapper validation
       uses: gradle/actions/wrapper-validation@v3
@@ -34,7 +34,7 @@ jobs:
     # 2. Running the nmcp plugin (requires Java 17+)
     # Note: TestNG artifacts still target Java 11 (targetJavaVersion=11)
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 21

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,7 +10,7 @@ jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Gradle wrapper validation
       uses: gradle/actions/wrapper-validation@v3
@@ -20,7 +20,7 @@ jobs:
     # 2. Running the nmcp plugin (requires Java 17+)
     # Note: TestNG artifacts still target Java 11 (targetJavaVersion=11)
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'zulu'
         java-version: 21

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       # Ask matrix.mjs to produce 7 jobs
       MATRIX_JOBS: 7
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - id: set-matrix
@@ -45,17 +45,17 @@ jobs:
     env:
       TZ: ${{ matrix.tz }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 10
       - name: Set up Java ${{ matrix.java_version }}, oracle
         if: ${{ matrix.oracle_java_website != '' }}
-        uses: oracle-actions/setup-java@2e744f723b003fdd759727d0ff654c8717024845 # v1.4.0
+        uses: oracle-actions/setup-java@fff43251af9936a0e6a4d5d0946e14f1680e9b6b # v1.5.0
         with:
           website: ${{ matrix.oracle_java_website }}
           release: ${{ matrix.java_version }}
       - name: Set up Java 21 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           # Install multiple Java versions:
           # - Test version (11, 17, 21, 25, or 26): Used to run TestNG tests
@@ -66,7 +66,7 @@ jobs:
           distribution: ${{ matrix.java_distribution }}
           architecture: x64
       - name: Steps to reproduce
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             console.log('The following command might help reproducing CI results, use Java ${{ matrix.java_version }}')
@@ -76,7 +76,7 @@ jobs:
         run: echo "unique_id=$(date +%s)" >> $GITHUB_OUTPUT
       - name: Test
         id: run_test_cases
-        uses: burrunan/gradle-cache-action@v2
+        uses: burrunan/gradle-cache-action@v3
         with:
           job-id: jdk${{ matrix.jdk.version }}
           arguments: |
@@ -93,7 +93,7 @@ jobs:
             org.gradle.java.installations.auto-download=false
       - name: Upload build reports
         if: ${{ failure() && steps.run_test_cases.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-reports-${{ matrix.jdk.group }}-${{ matrix.jdk.version }}-${{ steps.build_id.outputs.unique_id }}
           path: testng-core/build/reports/tests/test/**

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Fixes most deprecation warnings that Node20.js will stop working in June.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across all continuous integration workflows to the latest compatible releases. Changes include upgraded checkout (v6), Java setup, Gradle caching, and artifact upload utilities for improved workflow reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->