### PR TITLE
Clarify assertSame message for equivalent objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-561: Fixed assertSame failure message for equivalent but non-identical objects
 Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
 Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked
 Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -1583,6 +1583,15 @@ public class Assert {
     if (message != null) {
       formatted = message + " ";
     }
+    if (areEqual(actual, expected)) {
+      fail(
+          formatted
+              + ASSERT_EQUAL_LEFT
+              + expected
+              + "] but found equivalent but not same ["
+              + actual
+              + "]");
+    }
     fail(formatted + ASSERT_EQUAL_LEFT + expected + ASSERT_MIDDLE + actual + ASSERT_RIGHT);
   }
 

--- a/testng-asserts/src/test/java/org/testng/AssertTest.java
+++ b/testng-asserts/src/test/java/org/testng/AssertTest.java
@@ -532,6 +532,15 @@ public class AssertTest {
     Assert.assertSame(object2, object);
   }
 
+  @Test(
+      description = "GITHUB-561",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp =
+          "expected \\[foo\\] but found equivalent but not same \\[foo\\]")
+  public void testAssertSameEqualObjectsMessage() {
+    Assert.assertSame(new String("foo"), "foo");
+  }
+
   @Test(description = "GITHUB-2490")
   public void testAssertNotEqualsWithActualBrokenEqualsTrue() {
     // BrokenEqualsTrue.equals(Object) always returns true, even for null


### PR DESCRIPTION
Fixes testng-team/testng-asserts#10.

This clarifies the `assertSame` failure message when two objects are equivalent but not the same reference.

Validation:

* `.\gradlew.bat :testng-asserts:test`: PASS
* `git diff --check`: PASS
* `git show --check`: PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assertSame error messages to clearly distinguish between objects that are equivalent but not identical, making assertion failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->